### PR TITLE
agent_end: auto-complete in_progress tasks when LLM finishes turn

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,9 @@
  *   /tasks       — Interactive task management menu
  */
 
+import { existsSync, mkdirSync, writeFileSync, renameSync } from "node:fs";
 import { randomUUID } from "node:crypto";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 import { AutoClearManager } from "./auto-clear.js";
@@ -247,8 +248,22 @@ export default function (pi: ExtensionAPI) {
     if (taskScope === "session" && !piTasks) {
       const sessionId = ctx.sessionManager.getSessionId();
       const path = resolveStorePath(sessionId);
-      store = new TaskStore(path);
-      widget.setStore(store);
+      if (path) {
+        // Persist any in-memory tasks from the old (pre-session-ID) store to the
+        // new session-scoped file so they survive the store swap.
+        const oldTasks = store.list();
+        const newFileExists = existsSync(path);
+        if (oldTasks.length > 0 && !newFileExists) {
+          const tmpPath = path + ".tmp";
+          const maxId = Math.max(...oldTasks.map(t => parseInt(t.id, 10)), 0);
+          const data = { nextId: maxId + 1, tasks: oldTasks };
+          mkdirSync(dirname(path), { recursive: true });
+          writeFileSync(tmpPath, JSON.stringify(data, null, 2));
+          renameSync(tmpPath, path);
+        }
+        store = new TaskStore(path);
+        widget.setStore(store);
+      }
     }
     storeUpgraded = true;
   }
@@ -357,6 +372,33 @@ export default function (pi: ExtensionAPI) {
 
     upgradeStoreIfNeeded(ctx);
     showPersistedTasks(isResume);
+  });
+
+  // ── Prompt execution end: auto-complete in_progress tasks ──
+  // agent_end fires when the LLM stops producing tool calls — meaning the
+  // LLM is done for this turn. Any tasks still in_progress at that point
+  // should be marked completed.
+  //
+  // We skip the very first agent_end of the session (which fires on startup
+  // before the user sends any message) via the isFirstAgentCycle guard —
+  // agent_start toggles it to false on the first real turn.
+  let isFirstAgentCycle = true;
+  pi.on("agent_start" as any, () => { isFirstAgentCycle = false; });
+
+  pi.on("agent_end" as any, async () => {
+    if (isFirstAgentCycle) return;
+
+    const updated: string[] = [];
+    for (const task of store.list()) {
+      if (task.status === "in_progress") {
+        store.update(task.id, { status: "completed" });
+        updated.push(task.id);
+      }
+    }
+    if (updated.length > 0) {
+      debug(`agent_end: auto-completed in_progress tasks ${updated.join(", ")}`);
+      widget.update();
+    }
   });
 
   // Keep latestCtx fresh on every tool execution as well.


### PR DESCRIPTION
Adds two related fixes:

1. Auto-complete on agent_end: When the LLM stops producing tool calls (agent_end event), mark any in_progress tasks as completed. This matches the natural semantic of 'the LLM is done for this turn, so tasks it was working on are done'.

   Previously, only subagent-executed tasks were auto-completed via subagents:completed. Regular tasks required an explicit TaskUpdate call, which the LLM often forgot, leaving tasks stuck in_progress.

   The very first agent_end of the session (fired on startup before the user sends any message) is skipped via the isFirstAgentCycle guard.

2. Fix task loss across store upgrade: In session scope, the store starts in-memory before the session ID is known, then upgrades to file-backed once upgradeStoreIfNeeded() fires. Previously, the upgrade created a brand new empty TaskStore and the old in-memory tasks were GC'd \u2014 so any task created before the first turn_start was silently lost.

   Now we persist the old store's tasks to the new session file (atomic temp-file + rename, same pattern as TaskStore.save()) before swapping the store reference.

Without fix #2, fix #1 is only partially effective: agent_end fires but the in-memory task created in the same turn is in a different store instance than the file-backed one used later.