### PR TITLE
fix: simplify TaskUpdate status schema to flat enum

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -663,10 +663,8 @@ Set up task dependencies:
     parameters: Type.Object({
       taskId: Type.String({ description: "The ID of the task to update" }),
       status: Type.Optional(Type.Unsafe<"pending" | "in_progress" | "completed" | "deleted">({
-        anyOf: [
-          { type: "string", enum: ["pending", "in_progress", "completed"] },
-          { type: "string", const: "deleted" },
-        ],
+        type: "string",
+        enum: ["pending", "in_progress", "completed", "deleted"],
         description: "New status for the task",
       })),
       subject: Type.Optional(Type.String({ description: "New subject for the task" })),


### PR DESCRIPTION
## Problem

The `TaskUpdate` tool's `status` parameter used an `anyOf` schema with separate `enum` and `const` branches:

```json
{
  "anyOf": [
    { "type": "string", "enum": ["pending", "in_progress", "completed"] },
    { "type": "string", "const": "deleted" }
  ]
}
```

This caused LLM providers (Google Gemini, Anthropic Claude) to **double-quote** status values during tool call parsing, resulting in validation errors:

```
Validation failed for tool "TaskUpdate":
  - status: must be equal to one of the allowed values
  - status: must match a schema in anyOf

Received arguments:
{
  "taskId": "1",
  "status": "\"completed\""  // <-- double-quoted!
}
```

## Solution

Replace the `anyOf` structure with a single flat `enum` containing all allowed status values:

```json
{
  "type": "string",
  "enum": ["pending", "in_progress", "completed", "deleted"]
}
```

This schema is semantically equivalent but compatible with all LLM providers' tool call parsers.

## Testing

- Tested with Google Gemini provider (was failing before, works after)
- Schema remains type-safe via TypeScript generic: `Type.Unsafe<"pending" | "in_progress" | "completed" | "deleted">`


---

## Verification

**Fix tested and verified (2026-04-24)**

After reloading with this fix applied:
- `TaskCreate` — works correctly (3 test tasks created)
- `TaskList` — returns correct status values
- `TaskUpdate` — status enum transitions work without double-quoting
- All three test tasks successfully marked `completed`

No more `anyOf` schema double-quoting issues with Gemini/Claude providers.
