### PR TITLE
Persist task execution stats

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { AutoClearManager } from "./auto-clear.js";
 import { ProcessTracker } from "./process-tracker.js";
 import { TaskStore } from "./task-store.js";
 import { loadTasksConfig } from "./tasks-config.js";
+import { isCompletedTaskExecutionStats, isTaskExecutionStats } from "./types.js";
 import { openSettingsMenu } from "./ui/settings-menu.js";
 import { TaskWidget, type UICtx } from "./ui/task-widget.js";
 
@@ -36,6 +37,30 @@ function debug(...args: unknown[]) {
 
 function textResult(msg: string) {
   return { content: [{ type: "text" as const, text: msg }], details: undefined as any };
+}
+
+function formatDuration(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min < 60) return sec > 0 ? `${min}m ${sec}s` : `${min}m`;
+  const hr = Math.floor(min / 60);
+  const remMin = min % 60;
+  return remMin > 0 ? `${hr}h ${remMin}m` : `${hr}h`;
+}
+
+function formatTokens(n: number): string {
+  if (n < 1000) return String(n);
+  return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+}
+
+function formatClockTime(ms: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(ms);
 }
 
 /** Task tool names — used to detect task tool usage for reminder suppression. */
@@ -565,10 +590,33 @@ Returns full task details:
         lines.push(`Blocks: ${task.blocks.map(id => "#" + id).join(", ")}`);
       }
 
-      // Show metadata if non-empty
-      const metaKeys = Object.keys(task.metadata);
+      const executionStats = isTaskExecutionStats(task.metadata.executionStats)
+        ? task.metadata.executionStats
+        : undefined;
+      const completedStats = isCompletedTaskExecutionStats(task.metadata.executionStats)
+        ? task.metadata.executionStats
+        : undefined;
+      if (completedStats) {
+        const tokenParts: string[] = [];
+        if ((completedStats.inputTokens ?? 0) > 0) tokenParts.push(`↑ ${formatTokens(completedStats.inputTokens ?? 0)}`);
+        if ((completedStats.outputTokens ?? 0) > 0) tokenParts.push(`↓ ${formatTokens(completedStats.outputTokens ?? 0)}`);
+        lines.push(
+          `Execution stats: started ${formatClockTime(completedStats.startedAt)} · ` +
+          `ended ${formatClockTime(completedStats.completedAt ?? 0)} · ` +
+          `${formatDuration(completedStats.durationMs ?? 0)}` +
+          (tokenParts.length > 0 ? ` · ${tokenParts.join(" ")}` : "")
+        );
+      } else if (executionStats) {
+        lines.push(`Execution stats: started ${formatClockTime(executionStats.startedAt)}`);
+      }
+
+      // Show metadata if non-empty. When execution stats are valid, render them separately.
+      const metadataForDisplay = executionStats
+        ? Object.fromEntries(Object.entries(task.metadata).filter(([key]) => key !== "executionStats"))
+        : task.metadata;
+      const metaKeys = Object.keys(metadataForDisplay);
       if (metaKeys.length > 0) {
-        lines.push(`Metadata: ${JSON.stringify(task.metadata)}`);
+        lines.push(`Metadata: ${JSON.stringify(metadataForDisplay)}`);
       }
 
       return Promise.resolve(textResult(lines.join("\n")));

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,33 @@
 
 export type TaskStatus = "pending" | "in_progress" | "completed";
 
+export interface TaskExecutionStats {
+  startedAt: number;
+  completedAt?: number;
+  durationMs?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+export function isTaskExecutionStats(value: unknown): value is TaskExecutionStats {
+  if (!value || typeof value !== "object") return false;
+  const stats = value as Record<string, unknown>;
+  if (typeof stats.startedAt !== "number" || !Number.isFinite(stats.startedAt)) return false;
+  for (const key of ["completedAt", "durationMs", "inputTokens", "outputTokens"] as const) {
+    if (stats[key] !== undefined && (typeof stats[key] !== "number" || !Number.isFinite(stats[key]))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isCompletedTaskExecutionStats(value: unknown): value is Required<TaskExecutionStats> {
+  if (!isTaskExecutionStats(value)) return false;
+  const stats = value as TaskExecutionStats;
+  return [stats.completedAt, stats.durationMs, stats.inputTokens, stats.outputTokens]
+    .every((part) => typeof part === "number" && Number.isFinite(part));
+}
+
 export interface Task {
   id: string;
   subject: string;
@@ -11,7 +38,7 @@ export interface Task {
   status: TaskStatus;
   activeForm?: string;
   owner?: string;
-  metadata: Record<string, any>;
+  metadata: Record<string, any> & { executionStats?: TaskExecutionStats };
   blocks: string[];
   blockedBy: string[];
   createdAt: number;

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -10,6 +10,7 @@
 
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import type { TaskStore } from "../task-store.js";
+import { isCompletedTaskExecutionStats, isTaskExecutionStats, type Task, type TaskExecutionStats } from "../types.js";
 
 // ---- Types ----
 
@@ -58,6 +59,27 @@ function formatTokens(n: number): string {
   return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
 }
 
+/** Format a stable, human-readable clock time with second precision. */
+function formatClockTime(ms: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(ms);
+}
+
+function formatLiveStats(theme: Theme, metrics: TaskMetrics | undefined): string {
+  if (!metrics) return "";
+
+  const elapsed = formatDuration(Date.now() - metrics.startedAt);
+  const tokenParts: string[] = [];
+  if (metrics.inputTokens > 0) tokenParts.push(`↑ ${formatTokens(metrics.inputTokens)}`);
+  if (metrics.outputTokens > 0) tokenParts.push(`↓ ${formatTokens(metrics.outputTokens)}`);
+
+  const statParts = [`started ${formatClockTime(metrics.startedAt)}`, elapsed, ...tokenParts];
+  return ` ${theme.fg("dim", `(${statParts.join(" · ")})`)}`;
+}
+
 // ---- Widget ----
 
 export class TaskWidget {
@@ -83,16 +105,136 @@ export class TaskWidget {
     this.uiCtx = ctx;
   }
 
+  /** Persist the fact that a task started even before it completes. */
+  private persistStartMetrics(taskId: string, startedAt: number, existingStats?: TaskExecutionStats) {
+    this.store.update(taskId, {
+      metadata: {
+        executionStats: {
+          ...existingStats,
+          startedAt,
+          inputTokens: existingStats?.inputTokens ?? 0,
+          outputTokens: existingStats?.outputTokens ?? 0,
+        },
+      },
+    });
+  }
+
+  /** Infer a reasonable execution window for completed tasks that missed live tracking. */
+  private inferCompletedStats(task: Task, metrics?: TaskMetrics): Required<TaskExecutionStats> {
+    const existingStats = isTaskExecutionStats(task.metadata?.executionStats)
+      ? task.metadata.executionStats
+      : undefined;
+    if (metrics) {
+      const startedAt = existingStats?.startedAt ?? metrics.startedAt;
+      const completedAt = existingStats?.completedAt ?? task.updatedAt;
+      return {
+        startedAt,
+        completedAt,
+        durationMs: Math.max(0, completedAt - startedAt),
+        inputTokens: metrics.inputTokens,
+        outputTokens: metrics.outputTokens,
+      };
+    }
+    if (isCompletedTaskExecutionStats(existingStats)) return existingStats;
+
+    const blockerCompletedAt = task.blockedBy
+      .map((id) => this.store.get(id))
+      .flatMap((blocker) => {
+        if (!blocker || blocker.status !== "completed") return [];
+        const blockerStats = isTaskExecutionStats(blocker.metadata?.executionStats)
+          ? blocker.metadata.executionStats
+          : undefined;
+        return [blockerStats?.completedAt ?? blocker.updatedAt];
+      });
+    const startedAt = Math.max(task.createdAt, ...blockerCompletedAt);
+    return {
+      startedAt,
+      completedAt: task.updatedAt,
+      durationMs: Math.max(0, task.updatedAt - startedAt),
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+  }
+
+  /** Persist live metrics into task metadata when execution completes. */
+  private persistMetrics(taskId: string, task?: Task) {
+    const m = this.metrics.get(taskId);
+    const existingStats = isTaskExecutionStats(task?.metadata?.executionStats)
+      ? task.metadata.executionStats
+      : undefined;
+
+    if (task?.status === "completed" && (!isCompletedTaskExecutionStats(existingStats) || m)) {
+      this.store.update(taskId, { metadata: { executionStats: this.inferCompletedStats(task, m) } });
+    }
+
+    if (m) {
+      this.metrics.delete(taskId);
+    }
+  }
+
+  /** Rebuild timing baselines for persisted in-progress tasks after startup/resume. */
+  private syncTrackedTasks(tasks = this.store.list()) {
+    for (const task of tasks) {
+      if (task.status === "in_progress" && !this.metrics.has(task.id)) {
+        const existingStats = isTaskExecutionStats(task.metadata?.executionStats)
+          ? task.metadata.executionStats
+          : undefined;
+        const startedAt = existingStats?.startedAt ?? task.updatedAt;
+        this.metrics.set(task.id, {
+          startedAt,
+          inputTokens: existingStats?.inputTokens ?? 0,
+          outputTokens: existingStats?.outputTokens ?? 0,
+        });
+        if (!existingStats) {
+          this.persistStartMetrics(task.id, startedAt);
+        }
+      }
+    }
+
+    for (const [id] of this.metrics) {
+      const task = tasks.find(t => t.id === id) ?? this.store.get(id);
+      if (!task) {
+        this.activeTaskIds.delete(id);
+        this.metrics.delete(id);
+        continue;
+      }
+      if (task.status !== "in_progress") {
+        this.activeTaskIds.delete(id);
+        this.persistMetrics(id, task);
+      }
+    }
+
+    for (const task of tasks) {
+      if (task.status === "completed" && !isCompletedTaskExecutionStats(task.metadata?.executionStats)) {
+        this.store.update(task.id, { metadata: { executionStats: this.inferCompletedStats(task) } });
+      }
+    }
+  }
+
   /** Add or remove a task from the active spinner set. */
   setActiveTask(taskId: string | undefined, active = true) {
     if (taskId && active) {
       this.activeTaskIds.add(taskId);
+      const task = this.store.get(taskId);
+      const existingStats = isTaskExecutionStats(task?.metadata?.executionStats)
+        ? task.metadata.executionStats
+        : undefined;
       if (!this.metrics.has(taskId)) {
-        this.metrics.set(taskId, { startedAt: Date.now(), inputTokens: 0, outputTokens: 0 });
+        const startedAt = existingStats?.startedAt ?? Date.now();
+        this.metrics.set(taskId, {
+          startedAt,
+          inputTokens: existingStats?.inputTokens ?? 0,
+          outputTokens: existingStats?.outputTokens ?? 0,
+        });
+        if (!existingStats) {
+          this.persistStartMetrics(taskId, startedAt);
+        }
       }
       this.ensureTimer();
     } else if (taskId) {
       this.activeTaskIds.delete(taskId);
+      const task = this.store.get(taskId);
+      this.persistMetrics(taskId, task);
     }
     this.update();
   }
@@ -169,25 +311,31 @@ export class TaskWidget {
         const form = task.activeForm || task.subject;
         const agentId = task.metadata?.agentId;
         const agentLabel = agentId ? ` (agent ${agentId.slice(0, 5)})` : "";
-        const m = this.metrics.get(task.id);
-        let stats = "";
-        if (m) {
-          const elapsed = formatDuration(Date.now() - m.startedAt);
-          const tokenParts: string[] = [];
-          if (m.inputTokens > 0) tokenParts.push(`↑ ${formatTokens(m.inputTokens)}`);
-          if (m.outputTokens > 0) tokenParts.push(`↓ ${formatTokens(m.outputTokens)}`);
-          stats = tokenParts.length > 0
-            ? ` ${theme.fg("dim", `(${elapsed} · ${tokenParts.join(" ")})`)}`
-            : ` ${theme.fg("dim", `(${elapsed})`)}`;
-        }
+        const stats = formatLiveStats(theme, this.metrics.get(task.id));
         text = `  ${icon} ${theme.fg("dim", "#" + task.id)} ${theme.fg("accent", form + agentLabel + "…")}${stats}`;
       } else if (task.status === "completed") {
-        text = `  ${icon} ${theme.fg("dim", theme.strikethrough("#" + task.id + " " + task.subject))}`;
+        const stats = isCompletedTaskExecutionStats(task.metadata.executionStats)
+          ? task.metadata.executionStats
+          : undefined;
+        const statParts = stats
+          ? [
+            `started ${formatClockTime(stats.startedAt)}`,
+            `ended ${formatClockTime(stats.completedAt)}`,
+            formatDuration(stats.durationMs),
+            ...(stats.inputTokens > 0 ? [`↑ ${formatTokens(stats.inputTokens)}`] : []),
+            ...(stats.outputTokens > 0 ? [`↓ ${formatTokens(stats.outputTokens)}`] : []),
+          ]
+          : [];
+        const statSuffix = statParts.length > 0 ? ` ${theme.fg("dim", `(${statParts.join(" · ")})`)}` : "";
+        text = `  ${icon} ${theme.fg("dim", theme.strikethrough("#" + task.id + " " + task.subject))}${statSuffix}`;
       } else {
         const agentSuffix = task.status === "in_progress" && task.metadata?.agentId
           ? theme.fg("dim", ` (agent ${task.metadata.agentId.slice(0, 5)})`)
           : "";
-        text = `  ${icon} ${theme.fg("dim", "#" + task.id)} ${task.subject}${agentSuffix}`;
+        const stats = task.status === "in_progress"
+          ? formatLiveStats(theme, this.metrics.get(task.id))
+          : "";
+        text = `  ${icon} ${theme.fg("dim", "#" + task.id)} ${task.subject}${agentSuffix}${stats}`;
       }
 
       lines.push(truncate(text + suffix));
@@ -204,6 +352,7 @@ export class TaskWidget {
   update() {
     if (!this.uiCtx) return;
     const tasks = this.store.list();
+    this.syncTrackedTasks(tasks);
 
     // Transition: visible → hidden
     if (tasks.length === 0) {
@@ -216,15 +365,6 @@ export class TaskWidget {
         this.widgetInterval = undefined;
       }
       return;
-    }
-
-    // Prune stale active IDs (deleted or no longer in_progress)
-    for (const id of this.activeTaskIds) {
-      const t = this.store.get(id);
-      if (!t || t.status !== "in_progress") {
-        this.activeTaskIds.delete(id);
-        this.metrics.delete(id);
-      }
     }
 
     // Check if any task needs animation

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -503,6 +503,66 @@ describe("Standalone operation (no subagents extension)", () => {
     expect(result.content[0].text).toContain("in_progress");
   });
 
+  it("TaskGet shows persisted start time for in-progress tasks", async () => {
+    await mock.executeTool("TaskCreate", { subject: "Started", description: "desc" });
+    await mock.executeTool("TaskUpdate", {
+      taskId: "1",
+      metadata: {
+        executionStats: {
+          startedAt: 1_700_000_000_000,
+          inputTokens: 0,
+          outputTokens: 0,
+        },
+      },
+    });
+
+    const result = await mock.executeTool("TaskGet", { taskId: "1" });
+    expect(result.content[0].text).toContain("Execution stats: started");
+    expect(result.content[0].text).not.toContain("ended ");
+  });
+
+  it("TaskGet renders valid execution stats separately from metadata", async () => {
+    await mock.executeTool("TaskCreate", { subject: "Measured", description: "desc" });
+    await mock.executeTool("TaskUpdate", {
+      taskId: "1",
+      metadata: {
+        executionStats: {
+          startedAt: 1_700_000_000_000,
+          completedAt: 1_700_000_065_000,
+          durationMs: 65_000,
+          inputTokens: 1200,
+          outputTokens: 400,
+        },
+        note: "kept",
+      },
+    });
+
+    const result = await mock.executeTool("TaskGet", { taskId: "1" });
+    expect(result.content[0].text).toContain("Execution stats: started");
+    expect(result.content[0].text).toContain("1m 5s");
+    expect(result.content[0].text).toContain("↑ 1.2k");
+    expect(result.content[0].text).toContain("↓ 400");
+    expect(result.content[0].text).toContain('Metadata: {"note":"kept"}');
+    expect(result.content[0].text).not.toContain('"executionStats"');
+  });
+
+  it("TaskGet leaves malformed execution stats in raw metadata", async () => {
+    await mock.executeTool("TaskCreate", { subject: "Broken", description: "desc" });
+    await mock.executeTool("TaskUpdate", {
+      taskId: "1",
+      metadata: {
+        executionStats: {
+          startedAt: "bad",
+          completedAt: null,
+        },
+      },
+    });
+
+    const result = await mock.executeTool("TaskGet", { taskId: "1" });
+    expect(result.content[0].text).not.toContain("Execution stats:");
+    expect(result.content[0].text).toContain('Metadata: {"executionStats":{"startedAt":"bad","completedAt":null}}');
+  });
+
   it("TaskExecute gracefully refuses without subagents", async () => {
     await mock.executeTool("TaskCreate", {
       subject: "Agent task",

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -359,6 +359,31 @@ describe("TaskStore (file-backed)", () => {
     expect(store2.list()).toHaveLength(2);
   });
 
+  it("persists execution stats metadata to disk", () => {
+    const store1 = new TaskStore(testListId);
+    store1.create("Measured task", "Desc");
+    store1.update("1", {
+      metadata: {
+        executionStats: {
+          startedAt: 1_700_000_000_000,
+          completedAt: 1_700_000_060_000,
+          durationMs: 60_000,
+          inputTokens: 1200,
+          outputTokens: 400,
+        },
+      },
+    });
+
+    const store2 = new TaskStore(testListId);
+    expect(store2.get("1")!.metadata.executionStats).toEqual({
+      startedAt: 1_700_000_000_000,
+      completedAt: 1_700_000_060_000,
+      durationMs: 60_000,
+      inputTokens: 1200,
+      outputTokens: 400,
+    });
+  });
+
   it("restores all tasks across instances", () => {
     const store1 = new TaskStore(testListId);
     store1.create("Pending", "Desc");

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -79,7 +79,8 @@ describe("TaskWidget", () => {
     expect(lines[1]).toContain("Do something");
   });
 
-  it("renders in-progress tasks with ◼ icon", () => {
+  it("renders in-progress tasks with ◼ icon, start time, and duration", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
     store.create("Working on it", "Desc");
     store.update("1", { status: "in_progress" });
     widget.update();
@@ -87,6 +88,41 @@ describe("TaskWidget", () => {
     const lines = renderWidget(ui.state);
     expect(lines[1]).toContain("◼");
     expect(lines[1]).toContain("Working on it");
+    expect(lines[1]).toMatch(/started .*:\d{2}:\d{2}/);
+    expect(lines[1]).toContain("0s");
+  });
+
+  it("persists start time metadata for non-active in-progress tasks on update", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Plain in-progress", "Desc");
+
+    vi.advanceTimersByTime(60_000);
+    store.update("1", { status: "in_progress" });
+    widget.update();
+
+    expect(store.get("1")!.metadata.executionStats).toEqual({
+      startedAt: 1776092700000,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+  });
+
+  it("uses in-progress transition time when backfilling later completion stats", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Transition baseline", "Desc");
+
+    vi.advanceTimersByTime(60_000);
+    store.update("1", { status: "in_progress" });
+    widget.update();
+
+    vi.advanceTimersByTime(30_000);
+    store.update("1", { status: "completed" });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    expect(lines[1]).toContain("~~#1 Transition baseline~~");
+    expect(lines[1]).toContain("30s");
+    expect(lines[1]).not.toContain("1m 30s");
   });
 
   it("renders completed tasks with ✔ icon and strikethrough", () => {
@@ -99,7 +135,187 @@ describe("TaskWidget", () => {
     expect(lines[1]).toContain("~~#1 Done task~~");
   });
 
-  it("renders active tasks with spinner icon", () => {
+  it("persists start time metadata as soon as a task starts", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Started task", "Desc", "Working");
+    store.update("1", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+
+    expect(store.get("1")!.metadata.executionStats).toEqual({
+      startedAt: 1776092640000,
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+  });
+
+  it("persists completed task stats after execution finishes", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Finished task", "Desc", "Working");
+    store.update("1", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+
+    widget.addTokenUsage(1500, 800);
+    vi.advanceTimersByTime(65_000);
+
+    store.update("1", { status: "completed" });
+    widget.setActiveTask("1", false);
+
+    const lines = renderWidget(ui.state);
+    expect(lines[1]).toContain("~~#1 Finished task~~");
+    expect(lines[1]).toMatch(/started .*:\d{2}:\d{2}/);
+    expect(lines[1]).toMatch(/ended .*:\d{2}:\d{2}/);
+    expect(lines[1]).toContain("1m 5s");
+    expect(lines[1]).toContain("↑ 1.5k");
+    expect(lines[1]).toContain("↓ 800");
+  });
+
+  it("renders persisted completed stats after widget recreation", () => {
+    store.create("Remember stats", "Desc", "Working");
+    store.update("1", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+    widget.addTokenUsage(500, 200);
+
+    vi.advanceTimersByTime(5000);
+    store.update("1", { status: "completed" });
+    widget.setActiveTask("1", false);
+    widget.dispose();
+
+    const restoredUi = mockUICtx();
+    const restoredWidget = new TaskWidget(store);
+    restoredWidget.setUICtx(restoredUi.ctx);
+    restoredWidget.update();
+
+    const lines = renderWidget(restoredUi.state);
+    expect(lines[1]).toContain("~~#1 Remember stats~~");
+    expect(lines[1]).toMatch(/started .*:\d{2}:\d{2}/);
+    expect(lines[1]).toMatch(/ended .*:\d{2}:\d{2}/);
+    expect(lines[1]).toContain("5s");
+    expect(lines[1]).toContain("↑ 500");
+    expect(lines[1]).toContain("↓ 200");
+
+    restoredWidget.dispose();
+  });
+
+  it("uses the actual completion transition time when persisting stats later", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Delayed persist", "Desc", "Working");
+    store.update("1", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+
+    vi.advanceTimersByTime(65_000);
+    store.update("1", { status: "completed" });
+
+    vi.advanceTimersByTime(120_000);
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    expect(lines[1]).toContain("~~#1 Delayed persist~~");
+    expect(lines[1]).toContain("1m 5s");
+    expect(lines[1]).toMatch(/ended .*:05:05/);
+    expect(lines[1]).not.toContain("3m 5s");
+  });
+
+  it("rehydrates persisted in-progress tasks so completion stats survive resume", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Resume me", "Desc", "Working");
+    store.update("1", { status: "in_progress" });
+
+    const restoredUi = mockUICtx();
+    const restoredWidget = new TaskWidget(store);
+    restoredWidget.setUICtx(restoredUi.ctx);
+    restoredWidget.update();
+
+    vi.advanceTimersByTime(65_000);
+    store.update("1", { status: "completed" });
+    restoredWidget.update();
+
+    const lines = renderWidget(restoredUi.state);
+    expect(lines[1]).toContain("~~#1 Resume me~~");
+    expect(lines[1]).toContain("1m 5s");
+    expect(lines[1]).toMatch(/ended .*:05:05/);
+
+    restoredWidget.dispose();
+  });
+
+  it("renders persisted in-progress stats after widget recreation", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:05:30Z"));
+    store.create("Resume display", "Desc", undefined, {
+      executionStats: {
+        startedAt: Date.parse("2026-04-13T15:04:00Z"),
+        inputTokens: 1200,
+        outputTokens: 3400,
+      },
+    });
+    store.update("1", { status: "in_progress" });
+
+    const restoredUi = mockUICtx();
+    const restoredWidget = new TaskWidget(store);
+    restoredWidget.setUICtx(restoredUi.ctx);
+    restoredWidget.update();
+
+    const lines = renderWidget(restoredUi.state);
+    expect(lines[1]).toContain("◼");
+    expect(lines[1]).toContain("Resume display");
+    expect(lines[1]).toContain("1m 30s");
+    expect(lines[1]).toContain("↑ 1.2k");
+    expect(lines[1]).toContain("↓ 3.4k");
+
+    restoredWidget.dispose();
+  });
+
+  it("ignores malformed execution stats metadata when rendering completed tasks", () => {
+    store.create("Broken stats", "Desc");
+    store.update("1", {
+      status: "completed",
+      metadata: {
+        executionStats: { startedAt: "nope", completedAt: null },
+      } as any,
+    });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    expect(lines[1]).toContain("~~#1 Broken stats~~");
+    expect(lines[1]).toMatch(/started .*:\d{2}:\d{2}/);
+    expect(lines[1]).toMatch(/ended .*:\d{2}:\d{2}/);
+  });
+
+  it("backfills stats for direct pending-to-completed transitions", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Fast finish", "Desc");
+
+    vi.advanceTimersByTime(65_000);
+    store.update("1", { status: "completed" });
+    widget.setActiveTask("1", false);
+
+    const lines = renderWidget(ui.state);
+    expect(lines[1]).toContain("~~#1 Fast finish~~");
+    expect(lines[1]).toContain("1m 5s");
+    expect(lines[1]).not.toContain("↑");
+    expect(lines[1]).not.toContain("↓");
+  });
+
+  it("uses blocker completion time when backfilling direct completion stats", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
+    store.create("Blocker", "Desc");
+    store.create("Blocked", "Desc");
+    store.update("2", { addBlockedBy: ["1"] });
+
+    vi.advanceTimersByTime(60_000);
+    store.update("1", { status: "completed" });
+    widget.setActiveTask("1", false);
+
+    vi.advanceTimersByTime(120_000);
+    store.update("2", { status: "completed" });
+    widget.setActiveTask("2", false);
+
+    const lines = renderWidget(ui.state);
+    const blockedLine = lines.find(l => l.includes("Blocked"));
+    expect(blockedLine).toContain("2m");
+    expect(blockedLine).not.toContain("3m");
+  });
+
+  it("renders active tasks with spinner icon, start time, and duration", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
     store.create("Running thing", "Desc", "Processing data");
     store.update("1", { status: "in_progress" });
     widget.setActiveTask("1", true);
@@ -107,6 +323,8 @@ describe("TaskWidget", () => {
     const lines = renderWidget(ui.state);
     // Should show activeForm text with "…" suffix
     expect(lines[1]).toContain("Processing data…");
+    expect(lines[1]).toMatch(/started .*:\d{2}:\d{2}/);
+    expect(lines[1]).toContain("0s");
     // Should NOT show ◼ for active task
     expect(lines[1]).not.toContain("◼");
   });
@@ -183,6 +401,36 @@ describe("TaskWidget", () => {
     const activeLine = lines.find(l => l.includes("Running…"));
     expect(activeLine).toContain("↑ 1.5k");
     expect(activeLine).toContain("↓ 800");
+  });
+
+  it("preserves persisted start time and tokens when a resumed task becomes active", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:06:00Z"));
+    store.create("Resumed active", "Desc", "Continuing", {
+      executionStats: {
+        startedAt: Date.parse("2026-04-13T15:04:00Z"),
+        inputTokens: 1000,
+        outputTokens: 500,
+      },
+    });
+    store.update("1", { status: "in_progress" });
+
+    widget.setActiveTask("1", true);
+    widget.addTokenUsage(250, 125);
+
+    const lines = renderWidget(ui.state);
+    const activeLine = lines.find(l => l.includes("Continuing…"));
+    expect(activeLine).toContain("2m");
+    expect(activeLine).toContain("↑ 1.3k");
+    expect(activeLine).toContain("↓ 625");
+
+    store.update("1", { status: "completed" });
+    widget.setActiveTask("1", false);
+
+    expect(store.get("1")!.metadata.executionStats).toMatchObject({
+      startedAt: Date.parse("2026-04-13T15:04:00Z"),
+      inputTokens: 1250,
+      outputTokens: 625,
+    });
   });
 
   it("deactivates a task with setActiveTask(id, false)", () => {
@@ -263,7 +511,8 @@ describe("TaskWidget", () => {
     expect(lines[1]).toContain("My Subject…");
   });
 
-  it("shows elapsed time but no token arrows when tokens are zero", () => {
+  it("shows start time and elapsed time but no token arrows when tokens are zero", () => {
+    vi.setSystemTime(new Date("2026-04-13T15:04:00Z"));
     store.create("No tokens", "Desc", "Working");
     store.update("1", { status: "in_progress" });
     widget.setActiveTask("1", true);
@@ -274,6 +523,7 @@ describe("TaskWidget", () => {
 
     const lines = renderWidget(ui.state);
     const activeLine = lines.find(l => l.includes("Working…"));
+    expect(activeLine).toMatch(/started .*:\d{2}:\d{2}/);
     expect(activeLine).toContain("5s");
     expect(activeLine).not.toContain("↑");
     expect(activeLine).not.toContain("↓");


### PR DESCRIPTION
## Summary
- persist execution start metadata when tasks enter in-progress/active states
- backfill completed task execution stats for direct completions and resumed tasks
- render live and completed task timing/token stats consistently in the task widget
- add focused regression tests for persisted in-progress stats and completion backfill behavior

## Tests
- npm test -- task-widget
- npm test

Fixes #9