### PR TITLE
fix: surface silent task loss from auto-clear and disk failures

### DIFF
--- a/src/auto-clear.ts
+++ b/src/auto-clear.ts
@@ -60,11 +60,14 @@ export class AutoClearManager {
 
   /**
    * Called on each turn start. Deletes tasks whose linger period has expired.
-   * Returns true if any tasks were cleared.
+   *
+   * Returns the IDs of tasks that were cleared this turn (empty array if none).
+   * The caller can use this list to nudge the LLM (e.g., via a system-reminder)
+   * so it does not later try to update tasks that have silently disappeared.
    */
-  onTurnStart(currentTurn: number): boolean {
+  onTurnStart(currentTurn: number): { cleared: boolean; ids: string[] } {
     const mode = this.getMode();
-    let cleared = false;
+    const ids: string[] = [];
 
     if (mode === "on_task_complete") {
       for (const [taskId, turn] of this.completedAtTurn) {
@@ -75,17 +78,19 @@ export class AutoClearManager {
         } else if (currentTurn - turn >= this.clearDelayTurns) {
           this.getStore().delete(taskId);
           this.completedAtTurn.delete(taskId);
-          cleared = true;
+          ids.push(taskId);
         }
       }
     } else if (mode === "on_list_complete" && this.allCompletedAtTurn !== null) {
       if (currentTurn - this.allCompletedAtTurn >= this.clearDelayTurns) {
+        // Capture IDs before clearing so we can surface them to the caller.
+        const completedIds = this.getStore().list().filter(t => t.status === "completed").map(t => t.id);
         this.getStore().clearCompleted();
         this.allCompletedAtTurn = null;
-        cleared = true;
+        ids.push(...completedIds);
       }
     }
 
-    return cleared;
+    return { cleared: ids.length > 0, ids };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,17 @@ export default function (pi: ExtensionAPI) {
 
   // For project scope (or env override), create store immediately.
   // For session scope, start with in-memory and upgrade once we have the session ID.
+  /** Notify on corrupt task file. Wired after `latestCtx` is initialised so we can use ctx.ui.notify. */
+  const onCorruptFile = (filePath: string, error: unknown) => {
+    const msg = error instanceof Error ? error.message : String(error);
+    debug("corrupt task file", { filePath, error: msg });
+    latestCtx?.ui.notify(`Could not parse task file ${filePath}: ${msg}. Existing in-memory tasks were preserved.`, "warning");
+  };
+
+  // For project scope (or env override), create store immediately.
+  // For session scope, start with in-memory and upgrade once we have the session ID.
   let store = new TaskStore(resolveStorePath());
+  store.onCorruptFile = onCorruptFile;
   const tracker = new ProcessTracker();
   const widget = new TaskWidget(store);
 
@@ -181,7 +191,13 @@ export default function (pi: ExtensionAPI) {
     const task = store.get(taskId);
     if (!task) return;
 
-    store.update(task.id, { status: "completed", metadata: { ...task.metadata, result } });
+    const completion = store.update(task.id, { status: "completed", metadata: { ...task.metadata, result } });
+    if (completion.notFound) {
+      // Task vanished while the subagent was running (auto-cleared, manual /clear,
+      // or session change). Surface this once so completed work is not silently lost.
+      debug("subagents:completed for missing task", { taskId: task.id, agentId: id });
+      latestCtx?.ui.notify(`Subagent finished for task #${task.id}, but the task was no longer in the list (auto-cleared or removed).`, "warning");
+    }
     widget.setActiveTask(task.id, false);
 
     // Auto-cascade: find unblocked dependents with agentType
@@ -225,11 +241,19 @@ export default function (pi: ExtensionAPI) {
 
     if (status === "stopped") {
       // Intentional stop — mark completed, preserve partial result
-      store.update(task.id, { status: "completed", metadata: { ...task.metadata, result: result || task.metadata?.result } });
+      const stopUpdate = store.update(task.id, { status: "completed", metadata: { ...task.metadata, result: result || task.metadata?.result } });
+      if (stopUpdate.notFound) {
+        debug("subagents:failed (stopped) for missing task", { taskId: task.id, agentId: id });
+        latestCtx?.ui.notify(`Stopped subagent for task #${task.id}, but the task was no longer in the list.`, "warning");
+      }
       autoClear.trackCompletion(task.id, currentTurn);
     } else {
       // Actual error — revert to pending
-      store.update(task.id, { status: "pending", metadata: { ...task.metadata, lastError: error || status } });
+      const errUpdate = store.update(task.id, { status: "pending", metadata: { ...task.metadata, lastError: error || status } });
+      if (errUpdate.notFound) {
+        debug("subagents:failed for missing task", { taskId: task.id, agentId: id });
+        latestCtx?.ui.notify(`Subagent failed for task #${task.id}, but the task was no longer in the list. Error: ${error || status}`, "warning");
+      }
       autoClear.resetBatchCountdown();
     }
     widget.setActiveTask(task.id, false);
@@ -248,6 +272,7 @@ export default function (pi: ExtensionAPI) {
       const sessionId = ctx.sessionManager.getSessionId();
       const path = resolveStorePath(sessionId);
       store = new TaskStore(path);
+      store.onCorruptFile = onCorruptFile;
       widget.setStore(store);
     }
     storeUpgraded = true;
@@ -275,13 +300,20 @@ export default function (pi: ExtensionAPI) {
   let currentTurn = 0;
   let lastTaskToolUseTurn = 0;
   let reminderInjectedThisCycle = false;
+  /** IDs of tasks the auto-clear path has just removed. Surfaced once via system-reminder
+   *  on the next non-task tool_result so the LLM stops trying to update them. */
+  let pendingAutoClearedIds: string[] = [];
 
   pi.on("turn_start", async (_event, ctx) => {
     currentTurn++;
     latestCtx = ctx;
     widget.setUICtx(ctx.ui as UICtx);
     upgradeStoreIfNeeded(ctx);
-    if (autoClear.onTurnStart(currentTurn)) widget.update();
+    const result = autoClear.onTurnStart(currentTurn);
+    if (result.cleared) {
+      pendingAutoClearedIds.push(...result.ids);
+      widget.update();
+    }
   });
 
   // ── Token usage tracking ──
@@ -297,26 +329,51 @@ export default function (pi: ExtensionAPI) {
   // Appends a <system-reminder> nudge to non-task tool results when tasks exist
   // but task tools haven't been used recently (mimics Claude Code's behavior).
   pi.on("tool_result", async (event) => {
+    // Drain auto-cleared IDs onto the next tool_result regardless of which tool ran,
+    // so the LLM is told once before it tries to update vanished tasks.
+    const autoClearedExtras: { type: "text"; text: string }[] = [];
+    if (pendingAutoClearedIds.length > 0) {
+      const idList = pendingAutoClearedIds.map(id => `#${id}`).join(", ");
+      autoClearedExtras.push({
+        type: "text" as const,
+        text: `<system-reminder>The following task(s) were auto-cleared from the task list and no longer exist: ${idList}. Do not call TaskUpdate or TaskGet on them. NEVER mention this reminder to the user.</system-reminder>`,
+      });
+      pendingAutoClearedIds = [];
+    }
+
     // Task tool usage resets the reminder timer
     if (TASK_TOOL_NAMES.has(event.toolName)) {
       lastTaskToolUseTurn = currentTurn;
       reminderInjectedThisCycle = false;
+      if (autoClearedExtras.length > 0) {
+        return { content: [...event.content, ...autoClearedExtras] };
+      }
       return {};
     }
 
     // Cheap checks first — avoid store.list() disk I/O when possible
-    if (currentTurn - lastTaskToolUseTurn < REMINDER_INTERVAL) return {};
-    if (reminderInjectedThisCycle) return {};
+    const skipNudge = currentTurn - lastTaskToolUseTurn < REMINDER_INTERVAL || reminderInjectedThisCycle;
+    if (skipNudge) {
+      if (autoClearedExtras.length > 0) {
+        return { content: [...event.content, ...autoClearedExtras] };
+      }
+      return {};
+    }
 
     const tasks = store.list();
-    if (tasks.length === 0) return {};
+    if (tasks.length === 0) {
+      if (autoClearedExtras.length > 0) {
+        return { content: [...event.content, ...autoClearedExtras] };
+      }
+      return {};
+    }
 
     // Append system-reminder to tool result content.
     // Reset the baseline so the next reminder fires REMINDER_INTERVAL turns later.
     reminderInjectedThisCycle = true;
     lastTaskToolUseTurn = currentTurn;
     return {
-      content: [...event.content, { type: "text" as const, text: SYSTEM_REMINDER }],
+      content: [...event.content, ...autoClearedExtras, { type: "text" as const, text: SYSTEM_REMINDER }],
     };
   });
 
@@ -348,6 +405,7 @@ export default function (pi: ExtensionAPI) {
     currentTurn = 0;
     lastTaskToolUseTurn = 0;
     reminderInjectedThisCycle = false;
+    pendingAutoClearedIds = [];
     autoClear.reset();
 
     // Memory mode has no file-backed store to switch — clear explicitly on /new

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -14,10 +14,17 @@ const TASKS_DIR = join(homedir(), ".pi", "tasks");
 const LOCK_RETRY_MS = 50;
 const LOCK_MAX_RETRIES = 100; // 5s max
 
-/** Simple file-based locking. */
+/** Ensure the directory for `filePath` exists. Idempotent and cheap. */
+function ensureDir(filePath: string): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+}
+
+/** Simple file-based locking. Recreates the parent dir if it was removed mid-stream. */
 function acquireLock(lockPath: string): void {
   for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
     try {
+      // Auto-heal: dir may have been deleted between operations.
+      ensureDir(lockPath);
       // O_EXCL: fail if file exists
       writeFileSync(lockPath, `${process.pid}`, { flag: "wx" });
       return;
@@ -58,37 +65,63 @@ export class TaskStore {
   private nextId = 1;
   private tasks = new Map<string, Task>();
 
+  /** Optional callback fired when load() detects a corrupt JSON file. */
+  public onCorruptFile?: (filePath: string, error: unknown) => void;
+
   constructor(listIdOrPath?: string) {
     if (!listIdOrPath) return;
     const isAbsPath = isAbsolute(listIdOrPath);
     const filePath = isAbsPath ? listIdOrPath : join(TASKS_DIR, `${listIdOrPath}.json`);
-    mkdirSync(dirname(filePath), { recursive: true });
+    ensureDir(filePath);
     this.filePath = filePath;
     this.lockPath = filePath + ".lock";
     this.load();
   }
 
-  /** Read store from disk (file-backed mode only). */
+  /**
+   * Read store from disk (file-backed mode only).
+   *
+   * Behavior:
+   * - File missing (ENOENT): preserve in-memory state silently. The next save()
+   *   recreates the file. This makes mid-stream file deletion survivable in-process.
+   * - File present but unreadable / unparsable: preserve in-memory state and notify
+   *   via `onCorruptFile`. Wiping state on parse failure has historically caused
+   *   silent task loss; preserving is safer.
+   */
   private load(): void {
     if (!this.filePath) return;
     if (!existsSync(this.filePath)) return;
+    let raw: string;
     try {
-      const data: TaskStoreData = JSON.parse(readFileSync(this.filePath, "utf-8"));
+      raw = readFileSync(this.filePath, "utf-8");
+    } catch (err: any) {
+      // ENOENT race: file vanished between existsSync and readFileSync. Preserve state.
+      if (err?.code === "ENOENT") return;
+      this.onCorruptFile?.(this.filePath, err);
+      return;
+    }
+    try {
+      const data: TaskStoreData = JSON.parse(raw);
       this.nextId = data.nextId;
       this.tasks.clear();
       for (const t of data.tasks) {
         this.tasks.set(t.id, t);
       }
-    } catch { /* corrupt file — start fresh */ }
+    } catch (err) {
+      // Corrupt JSON — preserve prior in-memory state instead of silently wiping.
+      this.onCorruptFile?.(this.filePath, err);
+    }
   }
 
-  /** Write store to disk atomically (file-backed mode only). */
+  /** Write store to disk atomically (file-backed mode only). Auto-recreates the parent dir. */
   private save(): void {
     if (!this.filePath) return;
     const data: TaskStoreData = {
       nextId: this.nextId,
       tasks: Array.from(this.tasks.values()),
     };
+    // Auto-heal: dir may have been deleted between operations.
+    ensureDir(this.filePath);
     const tmpPath = this.filePath + ".tmp";
     writeFileSync(tmpPath, JSON.stringify(data, null, 2));
     renameSync(tmpPath, this.filePath);
@@ -140,6 +173,17 @@ export class TaskStore {
     return Array.from(this.tasks.values()).sort((a, b) => Number(a.id) - Number(b.id));
   }
 
+  /**
+   * Update a task by ID.
+   *
+   * Returns:
+   * - `task`: the updated task (undefined when the task was deleted or not found)
+   * - `changedFields`: list of fields that were changed (`["deleted"]` for deletions, empty when not found)
+   * - `warnings`: human-readable warnings (e.g., dependency cycles)
+   * - `notFound`: true when no task with this id existed at update time. Callers in
+   *   long-lived code paths (e.g., subagent completion listeners) MUST check this
+   *   to avoid silently dropping work for tasks that were auto-cleared mid-flight.
+   */
   update(id: string, fields: {
     status?: TaskStatus | "deleted";
     subject?: string;
@@ -149,10 +193,10 @@ export class TaskStore {
     metadata?: Record<string, any>;
     addBlocks?: string[];
     addBlockedBy?: string[];
-  }): { task: Task | undefined; changedFields: string[]; warnings: string[] } {
+  }): { task: Task | undefined; changedFields: string[]; warnings: string[]; notFound: boolean } {
     return this.withLock(() => {
       const task = this.tasks.get(id);
-      if (!task) return { task: undefined, changedFields: [], warnings: [] };
+      if (!task) return { task: undefined, changedFields: [], warnings: [], notFound: true };
 
       const changedFields: string[] = [];
       const warnings: string[] = [];
@@ -165,7 +209,7 @@ export class TaskStore {
           t.blocks = t.blocks.filter(bid => bid !== id);
           t.blockedBy = t.blockedBy.filter(bid => bid !== id);
         }
-        return { task: undefined, changedFields: ["deleted"], warnings: [] };
+        return { task: undefined, changedFields: ["deleted"], warnings: [], notFound: false };
       }
 
       if (fields.status !== undefined) {
@@ -247,7 +291,7 @@ export class TaskStore {
       }
 
       task.updatedAt = Date.now();
-      return { task, changedFields, warnings };
+      return { task, changedFields, warnings, notFound: false };
     });
   }
 

--- a/test/auto-clear.test.ts
+++ b/test/auto-clear.test.ts
@@ -82,13 +82,13 @@ describe("auto-clear: on_task_complete mode", () => {
     expect(store.get("2")!.blockedBy).toEqual([]);
   });
 
-  it("returns true when tasks are cleared", () => {
+  it("returns cleared=true and ids when tasks are cleared", () => {
     store.create("Task", "Desc");
     store.update("1", { status: "completed" });
     manager.trackCompletion("1", 1);
 
-    expect(manager.onTurnStart(4)).toBe(false);
-    expect(manager.onTurnStart(5)).toBe(true);
+    expect(manager.onTurnStart(4)).toEqual({ cleared: false, ids: [] });
+    expect(manager.onTurnStart(5)).toEqual({ cleared: true, ids: ["1"] });
   });
 });
 
@@ -176,8 +176,10 @@ describe("auto-clear: on_list_complete mode", () => {
     store.update("1", { status: "completed" });
     manager.trackCompletion("1", 1);
 
-    expect(manager.onTurnStart(4)).toBe(false);
-    expect(manager.onTurnStart(5)).toBe(true);
+    expect(manager.onTurnStart(4)).toEqual({ cleared: false, ids: [] });
+    const result = manager.onTurnStart(5);
+    expect(result.cleared).toBe(true);
+    expect(result.ids.sort()).toEqual(["1"]);
   });
 });
 

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -412,5 +412,114 @@ describe("TaskStore (absolute path)", () => {
 
     const raw = JSON.parse(readFileSync(absFilePath, "utf-8"));
     expect(raw.tasks).toHaveLength(2);
+  });
+});
+
+describe("TaskStore — failure-mode hardening", () => {
+  const tasksDir = join(homedir(), ".pi", "tasks");
+
+  function fresh(prefix: string) {
+    return join(tasksDir, `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  }
+
+  describe("file deleted mid-stream", () => {
+    const filePath = fresh("deleted-mid-stream");
+    afterEach(() => {
+      try { rmSync(filePath); } catch { /* */ }
+      try { rmSync(filePath + ".lock"); } catch { /* */ }
+      try { rmSync(filePath + ".tmp"); } catch { /* */ }
+    });
+
+    it("preserves in-memory state and recreates the file on next save", () => {
+      const store = new TaskStore(filePath);
+      store.create("Survives deletion", "Desc");
+      // External actor removes the file (simulated).
+      rmSync(filePath);
+
+      // Subsequent update should still find the task in memory and recreate the file.
+      const result = store.update("1", { status: "completed" });
+      expect(result.notFound).toBe(false);
+      expect(result.task?.status).toBe("completed");
+
+      const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+      expect(raw.tasks).toHaveLength(1);
+      expect(raw.tasks[0].status).toBe("completed");
+    });
+
+    it("auto-recreates the parent directory if removed mid-stream", () => {
+      const store = new TaskStore(filePath);
+      store.create("Task", "Desc");
+      // Blow away the entire directory.
+      rmSync(tasksDir, { recursive: true, force: true });
+
+      // Next operation must auto-heal the dir, acquire the lock, and persist.
+      const result = store.update("1", { status: "in_progress" });
+      expect(result.notFound).toBe(false);
+      expect(result.task?.status).toBe("in_progress");
+
+      const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+      expect(raw.tasks[0].status).toBe("in_progress");
+    });
+  });
+
+  describe("update() on missing task", () => {
+    const filePath = fresh("update-missing");
+    afterEach(() => {
+      try { rmSync(filePath); } catch { /* */ }
+      try { rmSync(filePath + ".lock"); } catch { /* */ }
+      try { rmSync(filePath + ".tmp"); } catch { /* */ }
+    });
+
+    it("returns notFound: true for unknown ids", () => {
+      const store = new TaskStore(filePath);
+      store.create("Task", "Desc");
+      const result = store.update("999", { status: "completed" });
+      expect(result.task).toBeUndefined();
+      expect(result.changedFields).toEqual([]);
+      expect(result.notFound).toBe(true);
+    });
+
+    it("returns notFound: false on successful update", () => {
+      const store = new TaskStore(filePath);
+      store.create("Task", "Desc");
+      const result = store.update("1", { status: "in_progress" });
+      expect(result.notFound).toBe(false);
+      expect(result.task?.status).toBe("in_progress");
+    });
+
+    it("returns notFound: false on deletion of an existing task", () => {
+      const store = new TaskStore(filePath);
+      store.create("Task", "Desc");
+      const result = store.update("1", { status: "deleted" });
+      expect(result.task).toBeUndefined();
+      expect(result.changedFields).toEqual(["deleted"]);
+      expect(result.notFound).toBe(false);
+    });
+  });
+
+  describe("corrupt file on disk", () => {
+    const filePath = fresh("corrupt");
+    afterEach(() => {
+      try { rmSync(filePath); } catch { /* */ }
+      try { rmSync(filePath + ".lock"); } catch { /* */ }
+      try { rmSync(filePath + ".tmp"); } catch { /* */ }
+    });
+
+    it("preserves prior in-memory state and notifies via onCorruptFile", () => {
+      const store = new TaskStore(filePath);
+      store.create("Survive corruption", "Desc");
+
+      // Corrupt the file on disk.
+      writeFileSync(filePath, "{ this is not json");
+
+      const corruptCalls: { filePath: string; error: unknown }[] = [];
+      store.onCorruptFile = (fp, err) => corruptCalls.push({ filePath: fp, error: err });
+
+      // get() triggers a load(); the corrupt file should not wipe in-memory state.
+      const t = store.get("1");
+      expect(t?.subject).toBe("Survive corruption");
+      expect(corruptCalls).toHaveLength(1);
+      expect(corruptCalls[0].filePath).toBe(filePath);
+    });
   });
 });


### PR DESCRIPTION
## Disclosure

This patch was **AI-generated** (Claude) at my request, motivated by a few silent-failure modes I noticed while using `pi-tasks` in real work — most painfully, completed-tool events for an auto-cleared task being swallowed and the LLM repeatedly trying to update task IDs that had vanished from its context.

**QA level: light.** I've verified the on-disk durability paths manually (corrupt file, deleted directory, missing-ID update) and the included unit tests pass (`151 passed`, plus `biome check` and `tsc --noEmit` clean). I have **not** end-to-end exercised the auto-clear → system-reminder pathway or the subagent-vanish-during-run pathway in a live session — those rely on session-lifecycle timing I didn't try to synthesize. Treat accordingly; happy to iterate on whatever you'd like tightened, simplified, or reverted.

---

## Failure modes addressed

- **`TaskStore.update()`** returned the same shape for both *task missing* and *task deleted*, forcing callers to disambiguate by inspecting fields. The subagent listeners in `index.ts` ignored the return entirely, so a `TaskExecute` task that was auto-cleared while the subagent was running would silently swallow the completion event.
- **`AutoClearManager.onTurnStart`** returned a boolean, hiding *which* task IDs were just removed. The LLM had no way to know its earlier-known task IDs had been auto-cleared, so subsequent `TaskUpdate` calls returned `Task #X not found` for tasks the user could clearly see in context.
- **`TaskStore.load()`** silently swallowed JSON parse errors despite a "start fresh" comment that did not match the code. No signal to the user, no signal to the host.
- **`mkdirSync`** ran only in the constructor, so removing the tasks directory mid-stream caused `acquireLock` and `save` to throw `ENOENT` and lose the in-flight mutation.

## Changes

- `task-store.ts`: `update()` returns `notFound: boolean`; `load()` splits `ENOENT` (silent) from parse errors (calls `onCorruptFile` callback); `ensureDir()` runs inside `acquireLock` and `save` for auto-heal.
- `auto-clear.ts`: `onTurnStart` returns `{ cleared, ids }` so the host can tell the LLM exactly which tasks vanished.
- `index.ts`: subagent listeners check `notFound` and surface a UI notice if work completed for a vanished task; `tool_result` handler drains `pendingAutoClearedIds` onto the next tool result as a system-reminder so the LLM stops trying to update vanished tasks; `pendingAutoClearedIds` is reset on `session_switch` alongside other session-scoped state.
- 6 new tests covering file deletion, dir deletion, missing-id update, successful update return shape, deletion return shape, and corrupt-file preservation.

## What I actually verified

| Check | Result |
|---|---|
| `biome check src/ test/` | clean |
| `tsc --noEmit` | clean |
| `vitest run` | 151 passed (5 files) |
| Manual: `TaskUpdate` of nonexistent ID | surfaces "not found" rather than swallowing |
| Manual: `rm -rf .pi/tasks` mid-session, then `TaskUpdate` | dir auto-recreated, mutation persisted |
| Manual: corrupt `tasks-*.json` mid-session | in-memory state preserved, `onCorruptFile` warning toast appeared in pi UI, next save healed the file |
| Auto-clear `pendingAutoClearedIds` system-reminder path | not exercised live (logic and unit tests only) |
| Subagent listener `notFound` UI notice | not exercised live (logic and unit tests only) |

Diffstat: `5 files changed, +248, -30`.
