### PR TITLE
feat: support batch task mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,17 @@ Create one or more structured tasks. Pass `tasks`, an array of task objects; use
 
 ### `TaskList`
 
-List all tasks with status, owner, and blocked-by info.
+List all tasks with status, owner, blocked-by info, and hierarchy summaries.
 
 ```
-#1 [pending] Fix authentication bug
-#2 [in_progress] Write unit tests (agent-1)
-#3 [pending] Update docs [blocked by #1, #2]
+#1 [pending] Deliver feature [container 1/3 done] [parallel #3, #4]
+  ↳ #2 [completed] Design API
+  ↳ #3 [pending] Implement API
+  ↳ #4 [pending] Write docs
+#5 [pending] Validate feature [blocked by #3, #4]
 ```
 
-Sort order: pending first, then in-progress, then completed (each group by ID).
+Flat lists sort pending first, then in-progress, then completed (each group by ID). Hierarchical lists render parent tasks with indented subtasks so container context stays visible.
 
 ### `TaskGet`
 
@@ -113,12 +115,14 @@ Task #2: Write unit tests
 Status: in_progress
 Owner: agent-1
 Description: Add tests for the auth module
+Parent: #1
+Parallel siblings: #4
 Blocked by: #1
 Blocks: #3
-Relations: validates #1
+Relations: parent #1, validates #1
 ```
 
-Shows owner (if set), open (non-completed) dependency edges, and non-blocking relationships. Non-empty metadata is displayed as JSON.
+For parent tasks, `TaskGet` also shows direct subtasks, aggregate subtask progress, available parallel subtasks, and ready-to-complete hints. Shows owner (if set), open dependency edges, and non-blocking relationships. Non-empty metadata is displayed as JSON.
 
 ### `TaskUpdate`
 
@@ -201,15 +205,50 @@ pending → in_progress → completed
 
 Tasks are created as `pending`. Mark `in_progress` before starting work, `completed` when done. `deleted` removes entirely — IDs never reset.
 
-## Dependency and Relationship Management
+## Dependency, Hierarchy, and Relationship Management
 
 - **Batch creation:** `TaskCreate` can create tasks and resolve temporary `key` references in one atomic mutation
 - **Bidirectional hard edges:** `blocks`/`blockedBy` and `addBlocks`/`addBlockedBy` maintain both sides automatically
+- **Hierarchy:** `relations: [{ "type": "parent", "target": "..." }]` nests a subtask under a parent/container task
+- **Parallel subtasks:** Siblings under the same parent with no hard dependency edge between them are shown as parallel-capable; multiple currently unblocked children are shown as `parallel #...`
 - **Non-blocking relations:** `relations`, `setRelations`, `addRelations`, and `removeRelations` record structure without blocking execution
+- **Completion hints:** Parent tasks show aggregate subtask progress and are reported as ready to complete once all subtasks are completed
 - **Dependency warnings:** cycles, self-dependencies, and references to non-existent tasks are stored but produce warnings in the tool response
 - **Display-time filtering:** `TaskList` only shows non-completed blockers in `[blocked by ...]`
 - **Raw data preserved:** `TaskGet` shows all hard edges and non-blocking relations
 - **Cleanup on deletion:** removing a task cleans up hard edges and relations pointing to it
+
+Example nested task set:
+
+```json
+{
+  "tasks": [
+    { "key": "feature", "subject": "Deliver feature", "description": "Container task" },
+    {
+      "key": "api",
+      "subject": "Implement API",
+      "description": "Build the endpoint",
+      "relations": [{ "type": "parent", "target": "feature" }]
+    },
+    {
+      "key": "docs",
+      "subject": "Write docs",
+      "description": "Document the endpoint",
+      "relations": [{ "type": "parent", "target": "feature" }]
+    },
+    {
+      "key": "validate",
+      "subject": "Validate feature",
+      "description": "Run checks after implementation and docs",
+      "blockedBy": ["api", "docs"],
+      "relations": [
+        { "type": "parent", "target": "feature" },
+        { "type": "validates", "target": "feature" }
+      ]
+    }
+  ]
+}
+```
 
 ## Task Storage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/1d0ee87a-e0a5-4bfa-a9b9-2f9144cb905b
 ## Features
 
 - **7 LLM-callable tools** — `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, `TaskExecute` — for task creation, updates, execution, and inspection
-- **Persistent widget** — live task list above the editor with `✔`/`◼`/`◻` status icons, task numbers (`#1`, `#2`, …), strikethrough for completed tasks, star spinner (`✳✽`) for active tasks with elapsed time and token counts
+- **Persistent widget** — live task list above the editor with `✔`/`◼`/`◻` status icons, task numbers (`#1`, `#2`, …), strikethrough for completed tasks, and a smooth spinner (`◐◓◑◒`) for active tasks with elapsed time and token counts
 - **System-reminder injection** — periodic `<system-reminder>` nudges appended to tool results when task tools haven't been used recently (matches Claude Code's behavior exactly)
 - **Prompt guidelines** — workflow contract encoded in tool descriptions, nudging the LLM at the point of tool use
 - **Dependency and relationship management** — hard `blocks`/`blockedBy` dependencies plus non-blocking relationships such as `parent`, `related`, `validates`, `supersedes`, and `orderAfter`
@@ -41,7 +41,7 @@ The extension renders a persistent widget above the editor:
 ```
 ● 4 tasks (1 done, 1 in progress, 2 open)
   ✔ #1 Design the flux capacitor
-  ✳ #2 Acquiring plutonium… (2m 49s · ↑ 4.1k ↓ 1.2k)
+  ◓ #2 Acquiring plutonium… (2m 49s · ↑ 4.1k ↓ 1.2k)
   ◻ #3 Install flux capacitor in DeLorean › blocked by #1
   ◻ #4 Test time travel at 88 mph › blocked by #2, #3
 ```
@@ -51,7 +51,7 @@ The extension renders a persistent widget above the editor:
 | `✔` | Completed (strikethrough + dim) |
 | `◼` | In-progress (not actively executing) |
 | `◻` | Pending |
-| `✳`/`✽` | Animated star spinner — actively executing task (shows `activeForm` text, elapsed time, token counts) |
+| `◐`/`◓`/`◑`/`◒` | Animated spinner — actively executing task (shows `activeForm` text, elapsed time, token counts) |
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ https://github.com/user-attachments/assets/1d0ee87a-e0a5-4bfa-a9b9-2f9144cb905b
 
 ## Features
 
-- **7 LLM-callable tools** — `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, `TaskExecute` — matching Claude Code's exact tool specs and descriptions
+- **7 LLM-callable tools** — `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, `TaskExecute` — for task creation, updates, execution, and inspection
 - **Persistent widget** — live task list above the editor with `✔`/`◼`/`◻` status icons, task numbers (`#1`, `#2`, …), strikethrough for completed tasks, star spinner (`✳✽`) for active tasks with elapsed time and token counts
 - **System-reminder injection** — periodic `<system-reminder>` nudges appended to tool results when task tools haven't been used recently (matches Claude Code's behavior exactly)
 - **Prompt guidelines** — workflow contract encoded in tool descriptions, nudging the LLM at the point of tool use
-- **Dependency management** — bidirectional `blocks`/`blockedBy` relationships with warnings for cycles, self-deps, and dangling references
+- **Dependency and relationship management** — hard `blocks`/`blockedBy` dependencies plus non-blocking relationships such as `parent`, `related`, `validates`, `supersedes`, and `orderAfter`
 - **Shared task lists** — multiple pi sessions can share a file-backed task list for agent team coordination
 - **File locking** — concurrent access is safe when multiple sessions share a task list
 - **Background process tracking** — track spawned processes with output buffering, blocking wait, and graceful stop
@@ -57,18 +57,39 @@ The extension renders a persistent widget above the editor:
 
 ### `TaskCreate`
 
-Create a structured task. Used proactively for complex multi-step work.
+Create one or more structured tasks. Pass `tasks`, an array of task objects; use one element for a single task.
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
+| Task field | Type | Required | Description |
+|------------|------|----------|-------------|
+| `key` | string | no | Temporary key for references inside this create call |
 | `subject` | string | yes | Brief imperative title |
 | `description` | string | yes | Detailed context and acceptance criteria |
 | `activeForm` | string | no | Present continuous form for spinner (e.g., "Running tests") |
 | `agentType` | string | no | Agent type for subagent execution (e.g., `"general-purpose"`, `"Explore"`) |
 | `metadata` | object | no | Arbitrary key-value pairs |
+| `blocks` | string[] | no | Task IDs or keys this task blocks |
+| `blockedBy` | string[] | no | Task IDs or keys that block this task |
+| `relations` | object[] | no | Non-blocking relationships with `type` and `target` |
+
+```json
+{
+  "tasks": [
+    { "key": "design", "subject": "Design API", "description": "Decide the shape" },
+    {
+      "key": "docs",
+      "subject": "Document API",
+      "description": "Write usage notes",
+      "blockedBy": ["design"],
+      "relations": [{ "type": "validates", "target": "design" }]
+    }
+  ]
+}
+```
 
 ```
-→ Task #1 created successfully: Fix authentication bug
+→ Created 2 tasks:
+#1 Design API
+#2 Document API
 ```
 
 ### `TaskList`
@@ -94,16 +115,17 @@ Owner: agent-1
 Description: Add tests for the auth module
 Blocked by: #1
 Blocks: #3
+Relations: validates #1
 ```
 
-Shows owner (if set) and open (non-completed) dependency edges. Non-empty metadata is displayed as JSON.
+Shows owner (if set), open (non-completed) dependency edges, and non-blocking relationships. Non-empty metadata is displayed as JSON.
 
 ### `TaskUpdate`
 
-Update task fields, status, metadata, and dependencies.
+Update one or more tasks. Pass `updates`, an array of update objects; use one element for a single task.
 
-| Parameter | Type | Description |
-|-----------|------|-------------|
+| Update field | Type | Description |
+|--------------|------|-------------|
 | `taskId` | string | Task ID (required) |
 | `status` | `pending` / `in_progress` / `completed` / `deleted` | New status |
 | `subject` | string | New title |
@@ -111,20 +133,29 @@ Update task fields, status, metadata, and dependencies.
 | `activeForm` | string | Spinner text |
 | `owner` | string | Agent name |
 | `metadata` | object | Shallow merge (null values delete keys) |
-| `addBlocks` | string[] | Task IDs this task blocks |
-| `addBlockedBy` | string[] | Task IDs that block this task |
+| `addBlocks` | string[] | Hard dependencies this task blocks |
+| `addBlockedBy` | string[] | Hard dependencies that block this task |
+| `setRelations` | object[] | Replace non-blocking relationships |
+| `addRelations` | object[] | Add non-blocking relationships |
+| `removeRelations` | object[] | Remove matching non-blocking relationships |
+
+```json
+{
+  "updates": [
+    { "taskId": "1", "status": "completed" },
+    { "taskId": "2", "status": "deleted" }
+  ]
+}
+```
 
 ```
 → Updated task #1 status
-→ Updated task #2 owner, status
-→ Updated task #3 blocks
-→ Updated task #3 blocks (warning: cycle: #3 and #1 block each other)
-→ Updated task #1 deleted
+→ Updated task #2 deleted
 ```
 
 Setting `status: "deleted"` permanently removes the task.
 
-Dependencies are bidirectional: `addBlocks: ["3"]` on task 1 also adds `blockedBy: ["1"]` to task 3.
+Dependencies are bidirectional: `addBlocks: ["3"]` on task 1 also adds `blockedBy: ["1"]` to task 3. Non-blocking `relations` are directional structure only and do not affect whether a task can start.
 
 ### `TaskOutput`
 
@@ -170,13 +201,15 @@ pending → in_progress → completed
 
 Tasks are created as `pending`. Mark `in_progress` before starting work, `completed` when done. `deleted` removes entirely — IDs never reset.
 
-## Dependency Management
+## Dependency and Relationship Management
 
-- **Bidirectional edges:** `addBlocks`/`addBlockedBy` maintain both sides automatically
+- **Batch creation:** `TaskCreate` can create tasks and resolve temporary `key` references in one atomic mutation
+- **Bidirectional hard edges:** `blocks`/`blockedBy` and `addBlocks`/`addBlockedBy` maintain both sides automatically
+- **Non-blocking relations:** `relations`, `setRelations`, `addRelations`, and `removeRelations` record structure without blocking execution
 - **Dependency warnings:** cycles, self-dependencies, and references to non-existent tasks are stored but produce warnings in the tool response
 - **Display-time filtering:** `TaskList` only shows non-completed blockers in `[blocked by ...]`
-- **Raw data preserved:** `TaskGet` shows ALL edges, including completed blockers
-- **Cleanup on deletion:** removing a task cleans up all edges pointing to it
+- **Raw data preserved:** `TaskGet` shows all hard edges and non-blocking relations
+- **Cleanup on deletion:** removing a task cleans up hard edges and relations pointing to it
 
 ## Task Storage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://github.com/user-attachments/assets/1d0ee87a-e0a5-4bfa-a9b9-2f9144cb905b
 ## Features
 
 - **7 LLM-callable tools** — `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, `TaskExecute` — for task creation, updates, execution, and inspection
-- **Persistent widget** — live task list above the editor with `✔`/`◼`/`◻` status icons, task numbers (`#1`, `#2`, …), strikethrough for completed tasks, and a smooth spinner (`◐◓◑◒`) for active tasks with elapsed time and token counts
+- **Persistent widget** — live task list above the editor with `✔`/`◼`/`◻` status icons, task numbers (`#1`, `#2`, …), strikethrough for completed tasks, and a Pi-style braille spinner (`⠋⠙⠹⠸`) for active tasks with elapsed time and token counts
 - **System-reminder injection** — periodic `<system-reminder>` nudges appended to tool results when task tools haven't been used recently (matches Claude Code's behavior exactly)
 - **Prompt guidelines** — workflow contract encoded in tool descriptions, nudging the LLM at the point of tool use
 - **Dependency and relationship management** — hard `blocks`/`blockedBy` dependencies plus non-blocking relationships such as `parent`, `related`, `validates`, `supersedes`, and `orderAfter`
@@ -41,7 +41,7 @@ The extension renders a persistent widget above the editor:
 ```
 ● 4 tasks (1 done, 1 in progress, 2 open)
   ✔ #1 Design the flux capacitor
-  ◓ #2 Acquiring plutonium… (2m 49s · ↑ 4.1k ↓ 1.2k)
+  ⠙ #2 Acquiring plutonium… (2m 49s · ↑ 4.1k ↓ 1.2k)
   ◻ #3 Install flux capacitor in DeLorean › blocked by #1
   ◻ #4 Test time travel at 88 mph › blocked by #2, #3
 ```
@@ -51,7 +51,7 @@ The extension renders a persistent widget above the editor:
 | `✔` | Completed (strikethrough + dim) |
 | `◼` | In-progress (not actively executing) |
 | `◻` | Pending |
-| `◐`/`◓`/`◑`/`◒` | Animated spinner — actively executing task (shows `activeForm` text, elapsed time, token counts) |
+| `⠋`/`⠙`/`⠹`/`⠸` | Animated braille spinner — actively executing task (shows `activeForm` text, elapsed time, token counts) |
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ List all tasks with status, owner, blocked-by info, and hierarchy summaries.
 
 ```
 #1 [pending] Deliver feature [container 1/3 done] [parallel #3, #4]
-  ↳ #2 [completed] Design API
-  ↳ #3 [pending] Implement API
-  ↳ #4 [pending] Write docs
+├─ #2 [completed] Design API
+├─ #3 [pending] Implement API
+└─ #4 [pending] Write docs
 #5 [pending] Validate feature [blocked by #3, #4]
 ```
 
-Flat lists sort pending first, then in-progress, then completed (each group by ID). Hierarchical lists render parent tasks with indented subtasks so container context stays visible.
+Flat lists sort pending first, then in-progress, then completed (each group by ID). Hierarchical lists render parent tasks with tree connectors so container context stays visible.
 
 ### `TaskGet`
 

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -18,6 +18,7 @@ export interface TaskHierarchy {
 export interface TaskHierarchyRow {
   task: Task;
   depth: number;
+  connectorPrefix: string;
   parentId: string | undefined;
   summary: SubtaskSummary;
   readyToComplete: boolean;
@@ -153,13 +154,14 @@ export function flattenTaskHierarchy(hierarchy: TaskHierarchy): TaskHierarchyRow
   const emitted = new Set<string>();
   const rootOrder = hierarchy.hasHierarchy ? byId : byStatusThenId;
 
-  function append(task: Task, depth: number, path: Set<string>) {
+  function append(task: Task, depth: number, connectorPrefix: string, childPrefix: string, path: Set<string>) {
     if (emitted.has(task.id)) return;
     emitted.add(task.id);
 
     rows.push({
       task,
       depth,
+      connectorPrefix,
       parentId: getParentId(task.id, hierarchy),
       summary: getSubtaskSummary(task.id, hierarchy),
       readyToComplete: isReadyToComplete(task, hierarchy),
@@ -170,17 +172,26 @@ export function flattenTaskHierarchy(hierarchy: TaskHierarchy): TaskHierarchyRow
     if (path.has(task.id)) return;
     const nextPath = new Set(path);
     nextPath.add(task.id);
-    for (const child of getChildren(task.id, hierarchy)) {
-      append(child, depth + 1, nextPath);
+    const children = getChildren(task.id, hierarchy);
+    for (let index = 0; index < children.length; index++) {
+      const child = children[index];
+      const isLast = index === children.length - 1;
+      append(
+        child,
+        depth + 1,
+        `${childPrefix}${isLast ? "└─ " : "├─ "}`,
+        `${childPrefix}${isLast ? "   " : "│  "}`,
+        nextPath,
+      );
     }
   }
 
   for (const root of [...hierarchy.roots].sort(rootOrder)) {
-    append(root, 0, new Set());
+    append(root, 0, "", "", new Set());
   }
 
   for (const task of [...hierarchy.tasks].sort(byId)) {
-    append(task, 0, new Set());
+    append(task, 0, "", "", new Set());
   }
 
   return rows;

--- a/src/hierarchy.ts
+++ b/src/hierarchy.ts
@@ -1,0 +1,191 @@
+import type { Task } from "./types.js";
+
+export interface SubtaskSummary {
+  completed: number;
+  total: number;
+  allCompleted: boolean;
+}
+
+export interface TaskHierarchy {
+  tasks: Task[];
+  tasksById: Map<string, Task>;
+  parentByChild: Map<string, string>;
+  childrenByParent: Map<string, Task[]>;
+  roots: Task[];
+  hasHierarchy: boolean;
+}
+
+export interface TaskHierarchyRow {
+  task: Task;
+  depth: number;
+  parentId: string | undefined;
+  summary: SubtaskSummary;
+  readyToComplete: boolean;
+  availableChildIds: string[];
+  parallelSiblingIds: string[];
+}
+
+const STATUS_ORDER: Record<string, number> = { pending: 0, in_progress: 1, completed: 2 };
+
+function byId(a: Task, b: Task): number {
+  return Number(a.id) - Number(b.id);
+}
+
+export function byStatusThenId(a: Task, b: Task): number {
+  const statusDelta = (STATUS_ORDER[a.status] ?? 0) - (STATUS_ORDER[b.status] ?? 0);
+  if (statusDelta !== 0) return statusDelta;
+  return byId(a, b);
+}
+
+function findPrimaryParentId(task: Task, tasksById: Map<string, Task>): string | undefined {
+  return (task.relations ?? []).find(relation => (
+    relation.type === "parent" &&
+    relation.target !== task.id &&
+    tasksById.has(relation.target)
+  ))?.target;
+}
+
+export function buildTaskHierarchy(tasks: Task[]): TaskHierarchy {
+  const tasksById = new Map(tasks.map(task => [task.id, task]));
+  const parentByChild = new Map<string, string>();
+  const childrenByParent = new Map<string, Task[]>();
+
+  for (const task of tasks) {
+    const parentId = findPrimaryParentId(task, tasksById);
+    if (!parentId) continue;
+    parentByChild.set(task.id, parentId);
+    const siblings = childrenByParent.get(parentId) ?? [];
+    siblings.push(task);
+    childrenByParent.set(parentId, siblings);
+  }
+
+  for (const siblings of childrenByParent.values()) {
+    siblings.sort(byId);
+  }
+
+  return {
+    tasks,
+    tasksById,
+    parentByChild,
+    childrenByParent,
+    roots: tasks.filter(task => !parentByChild.has(task.id)),
+    hasHierarchy: parentByChild.size > 0,
+  };
+}
+
+export function getParentId(taskId: string, hierarchy: TaskHierarchy): string | undefined {
+  return hierarchy.parentByChild.get(taskId);
+}
+
+export function getChildren(taskId: string, hierarchy: TaskHierarchy): Task[] {
+  return hierarchy.childrenByParent.get(taskId) ?? [];
+}
+
+export function getDescendantIds(taskId: string, hierarchy: TaskHierarchy): string[] {
+  const descendants: string[] = [];
+  const seen = new Set<string>([taskId]);
+
+  function visit(id: string) {
+    for (const child of getChildren(id, hierarchy)) {
+      if (seen.has(child.id)) continue;
+      seen.add(child.id);
+      descendants.push(child.id);
+      visit(child.id);
+    }
+  }
+
+  visit(taskId);
+  return descendants;
+}
+
+export function getSubtaskSummary(taskId: string, hierarchy: TaskHierarchy): SubtaskSummary {
+  const descendants = getDescendantIds(taskId, hierarchy);
+  const completed = descendants.filter(id => hierarchy.tasksById.get(id)?.status === "completed").length;
+  return {
+    completed,
+    total: descendants.length,
+    allCompleted: descendants.length > 0 && completed === descendants.length,
+  };
+}
+
+export function getOpenBlockerIds(task: Task, hierarchy: TaskHierarchy): string[] {
+  return task.blockedBy.filter(blockerId => {
+    const blocker = hierarchy.tasksById.get(blockerId);
+    return !blocker || blocker.status !== "completed";
+  });
+}
+
+export function getAvailableChildIds(taskId: string, hierarchy: TaskHierarchy): string[] {
+  return getChildren(taskId, hierarchy)
+    .filter(child => child.status === "pending" && getOpenBlockerIds(child, hierarchy).length === 0)
+    .map(child => child.id);
+}
+
+function hasHardOrderingBetween(a: Task, b: Task): boolean {
+  return a.blocks.includes(b.id) || a.blockedBy.includes(b.id) || b.blocks.includes(a.id) || b.blockedBy.includes(a.id);
+}
+
+export function getParallelSiblingIds(taskId: string, hierarchy: TaskHierarchy): string[] {
+  const task = hierarchy.tasksById.get(taskId);
+  if (!task || task.status === "completed") return [];
+
+  const parentId = getParentId(taskId, hierarchy);
+  if (!parentId) return [];
+
+  return getChildren(parentId, hierarchy)
+    .filter(sibling => sibling.id !== taskId && sibling.status !== "completed" && !hasHardOrderingBetween(task, sibling))
+    .map(sibling => sibling.id);
+}
+
+export function isReadyToComplete(task: Task, hierarchy: TaskHierarchy): boolean {
+  const summary = getSubtaskSummary(task.id, hierarchy);
+  return task.status !== "completed" && summary.allCompleted;
+}
+
+export function getReadyParentIds(hierarchy: TaskHierarchy): string[] {
+  return hierarchy.tasks
+    .filter(task => isReadyToComplete(task, hierarchy))
+    .map(task => task.id);
+}
+
+export function flattenTaskHierarchy(hierarchy: TaskHierarchy): TaskHierarchyRow[] {
+  const rows: TaskHierarchyRow[] = [];
+  const emitted = new Set<string>();
+  const rootOrder = hierarchy.hasHierarchy ? byId : byStatusThenId;
+
+  function append(task: Task, depth: number, path: Set<string>) {
+    if (emitted.has(task.id)) return;
+    emitted.add(task.id);
+
+    rows.push({
+      task,
+      depth,
+      parentId: getParentId(task.id, hierarchy),
+      summary: getSubtaskSummary(task.id, hierarchy),
+      readyToComplete: isReadyToComplete(task, hierarchy),
+      availableChildIds: getAvailableChildIds(task.id, hierarchy),
+      parallelSiblingIds: getParallelSiblingIds(task.id, hierarchy),
+    });
+
+    if (path.has(task.id)) return;
+    const nextPath = new Set(path);
+    nextPath.add(task.id);
+    for (const child of getChildren(task.id, hierarchy)) {
+      append(child, depth + 1, nextPath);
+    }
+  }
+
+  for (const root of [...hierarchy.roots].sort(rootOrder)) {
+    append(root, 0, new Set());
+  }
+
+  for (const task of [...hierarchy.tasks].sort(byId)) {
+    append(task, 0, new Set());
+  }
+
+  return rows;
+}
+
+export function formatTaskRefs(ids: string[]): string {
+  return ids.map(id => `#${id}`).join(", ");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,18 @@ import { join, resolve } from "node:path";
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { Type } from "typebox";
 import { AutoClearManager } from "./auto-clear.js";
+import {
+  buildTaskHierarchy,
+  flattenTaskHierarchy,
+  formatTaskRefs,
+  getAvailableChildIds,
+  getChildren,
+  getOpenBlockerIds,
+  getParallelSiblingIds,
+  getParentId,
+  getReadyParentIds,
+  getSubtaskSummary,
+} from "./hierarchy.js";
 import { ProcessTracker } from "./process-tracker.js";
 import { TaskStore } from "./task-store.js";
 import { loadTasksConfig } from "./tasks-config.js";
@@ -553,7 +565,9 @@ Returns a summary of each task:
 - **status**: 'pending', 'in_progress', or 'completed'
 - **owner**: Agent ID if assigned, empty if available
 - **blockedBy**: List of open task IDs that must be resolved first (tasks with blockedBy cannot be claimed until dependencies resolve)
+- **container progress**: Parent tasks show subtask completion and ready-to-complete hints
 
+Container rows group subtasks; prefer claiming unblocked leaf tasks unless the parent itself has explicit work.
 Use TaskGet with a specific task ID to view full details including description and comments.`,
     parameters: Type.Object({}),
 
@@ -561,30 +575,24 @@ Use TaskGet with a specific task ID to view full details including description a
       const tasks = store.list();
       if (tasks.length === 0) return Promise.resolve(textResult("No tasks found"));
 
-      // Sort: pending first (by ID), then in_progress (by ID), then completed (by ID)
-      const statusOrder: Record<string, number> = { pending: 0, in_progress: 1, completed: 2 };
-      const sorted = [...tasks].sort((a, b) => {
-        const so = (statusOrder[a.status] ?? 0) - (statusOrder[b.status] ?? 0);
-        if (so !== 0) return so;
-        return Number(a.id) - Number(b.id);
-      });
+      const hierarchy = buildTaskHierarchy(tasks);
+      const lines = flattenTaskHierarchy(hierarchy).map(row => {
+        const indent = row.depth > 0 ? `${"  ".repeat(row.depth)}↳ ` : "";
+        let line = `${indent}#${row.task.id} [${row.task.status}] ${row.task.subject}`;
 
-      const lines = sorted.map(task => {
-        let line = `#${task.id} [${task.status}] ${task.subject}`;
-
-        if (task.owner) {
-          line += ` (${task.owner})`;
+        if (row.task.owner) {
+          line += ` (${row.task.owner})`;
         }
 
-        // Only show non-completed blockers
-        if (task.blockedBy.length > 0) {
-          const openBlockers = task.blockedBy.filter(bid => {
-            const blocker = store.get(bid);
-            return blocker && blocker.status !== "completed";
-          });
-          if (openBlockers.length > 0) {
-            line += ` [blocked by ${openBlockers.map(id => "#" + id).join(", ")}]`;
-          }
+        if (row.summary.total > 0) {
+          line += ` [container ${row.summary.completed}/${row.summary.total} done]`;
+          if (row.readyToComplete) line += " [ready to complete]";
+          if (row.availableChildIds.length > 1) line += ` [parallel ${formatTaskRefs(row.availableChildIds)}]`;
+        }
+
+        const openBlockers = getOpenBlockerIds(row.task, hierarchy);
+        if (openBlockers.length > 0) {
+          line += ` [blocked by ${formatTaskRefs(openBlockers)}]`;
         }
 
         return line;
@@ -617,6 +625,7 @@ Returns full task details:
 - **status**: 'pending', 'in_progress', or 'completed'
 - **blocks**: Tasks waiting on this one to complete
 - **blockedBy**: Tasks that must complete before this one can start
+- **parent/subtasks**: Hierarchy, aggregate progress, parallel-capable siblings, and ready-to-complete hints
 
 ## Tips
 
@@ -642,17 +651,37 @@ Returns full task details:
       }
       lines.push(`Description: ${desc}`);
 
-      if (task.blockedBy.length > 0) {
-        const openBlockers = task.blockedBy.filter(bid => {
-          const blocker = store.get(bid);
-          return blocker && blocker.status !== "completed";
-        });
-        if (openBlockers.length > 0) {
-          lines.push(`Blocked by: ${openBlockers.map(id => "#" + id).join(", ")}`);
+      const hierarchy = buildTaskHierarchy(store.list());
+      const parentId = getParentId(task.id, hierarchy);
+      if (parentId) {
+        lines.push(`Parent: #${parentId}`);
+      }
+
+      const children = getChildren(task.id, hierarchy);
+      if (children.length > 0) {
+        const summary = getSubtaskSummary(task.id, hierarchy);
+        lines.push(`Subtasks: ${formatTaskRefs(children.map(child => child.id))}`);
+        lines.push(`Subtask progress: ${summary.completed}/${summary.total} completed`);
+        const availableChildIds = getAvailableChildIds(task.id, hierarchy);
+        if (availableChildIds.length > 1) {
+          lines.push(`Available parallel subtasks: ${formatTaskRefs(availableChildIds)}`);
+        }
+        if (summary.allCompleted && task.status !== "completed") {
+          lines.push("All subtasks are complete; consider marking this parent completed.");
         }
       }
+
+      const parallelSiblingIds = getParallelSiblingIds(task.id, hierarchy);
+      if (parallelSiblingIds.length > 0) {
+        lines.push(`Parallel siblings: ${formatTaskRefs(parallelSiblingIds)}`);
+      }
+
+      const openBlockers = getOpenBlockerIds(task, hierarchy);
+      if (openBlockers.length > 0) {
+        lines.push(`Blocked by: ${formatTaskRefs(openBlockers)}`);
+      }
       if (task.blocks.length > 0) {
-        lines.push(`Blocks: ${task.blocks.map(id => "#" + id).join(", ")}`);
+        lines.push(`Blocks: ${formatTaskRefs(task.blocks)}`);
       }
       if (task.relations.length > 0) {
         lines.push(`Relations: ${formatRelations(task.relations)}`);
@@ -760,6 +789,16 @@ Add a soft ordering relationship:
       }
 
       if (warnings.length > 0) lines.push(`Warnings: ${warnings.join("; ")}`);
+      if (updates.some(update => update.status === "completed" || update.status === "deleted")) {
+        const hierarchy = buildTaskHierarchy(store.list());
+        const readyParents = getReadyParentIds(hierarchy);
+        if (readyParents.length > 0) {
+          lines.push(`Ready to complete: ${readyParents.map(id => {
+            const summary = getSubtaskSummary(id, hierarchy);
+            return `#${id} (${summary.completed}/${summary.total} subtasks done)`;
+          }).join(", ")}`);
+        }
+      }
       widget.update();
       return Promise.resolve(textResult(lines.join("\n")));
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,10 @@
  * @tintinweb/pi-tasks — A pi extension providing Claude Code-style task tracking and coordination.
  *
  * Tools:
- *   TaskCreate   — Create a structured task
+ *   TaskCreate   — Create one or more structured tasks
  *   TaskList     — List all tasks with status
  *   TaskGet      — Get full task details
- *   TaskUpdate   — Update task fields, status, dependencies
+ *   TaskUpdate   — Update task fields, status, dependencies, and relations
  *   TaskOutput   — Get output from a background task process
  *   TaskStop     — Stop a running background task process
  *   TaskExecute  — Execute tasks as subagents (requires @tintinweb/pi-subagents)
@@ -22,6 +22,7 @@ import { AutoClearManager } from "./auto-clear.js";
 import { ProcessTracker } from "./process-tracker.js";
 import { TaskStore } from "./task-store.js";
 import { loadTasksConfig } from "./tasks-config.js";
+import type { TaskCreateInput, TaskRelation, TaskUpdateFields } from "./types.js";
 import { openSettingsMenu } from "./ui/settings-menu.js";
 import { TaskWidget, type UICtx } from "./ui/task-widget.js";
 
@@ -36,6 +37,63 @@ function debug(...args: unknown[]) {
 
 function textResult(msg: string) {
   return { content: [{ type: "text" as const, text: msg }], details: undefined as any };
+}
+
+const TaskRelationSchema = Type.Object({
+  type: Type.String({ description: "Relationship type, e.g. parent, related, validates, supersedes, or orderAfter" }),
+  target: Type.String({ description: "Target task ID, or a create-batch key when used inside TaskCreate" }),
+});
+
+const TaskCreateItemSchema = Type.Object({
+  key: Type.Optional(Type.String({ description: "Temporary key for references within this TaskCreate call" })),
+  subject: Type.String({ description: "A brief title for the task" }),
+  description: Type.String({ description: "A detailed description of what needs to be done" }),
+  activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in the spinner when in_progress" })),
+  agentType: Type.Optional(Type.String({ description: "Agent type for subagent execution" })),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Arbitrary metadata to attach to the task" })),
+  blocks: Type.Optional(Type.Array(Type.String(), { description: "Task IDs or create-batch keys this task blocks" })),
+  blockedBy: Type.Optional(Type.Array(Type.String(), { description: "Task IDs or create-batch keys that block this task" })),
+  relations: Type.Optional(Type.Array(TaskRelationSchema, { description: "Non-blocking task relationships" })),
+});
+
+const TaskUpdateItemSchema = Type.Object({
+  taskId: Type.String({ description: "The ID of the task to update" }),
+  status: Type.Optional(Type.Unsafe<"pending" | "in_progress" | "completed" | "deleted">({
+    type: "string",
+    enum: ["pending", "in_progress", "completed", "deleted"],
+    description: "New status for the task",
+  })),
+  subject: Type.Optional(Type.String({ description: "New subject for the task" })),
+  description: Type.Optional(Type.String({ description: "New description for the task" })),
+  activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in the spinner when in_progress" })),
+  owner: Type.Optional(Type.String({ description: "New owner for the task" })),
+  metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Metadata keys to merge into the task. Set a key to null to delete it." })),
+  addBlocks: Type.Optional(Type.Array(Type.String(), { description: "Task IDs that this task blocks" })),
+  addBlockedBy: Type.Optional(Type.Array(Type.String(), { description: "Task IDs that block this task" })),
+  setRelations: Type.Optional(Type.Array(TaskRelationSchema, { description: "Replace non-blocking relationships for this task" })),
+  addRelations: Type.Optional(Type.Array(TaskRelationSchema, { description: "Add non-blocking relationships to this task" })),
+  removeRelations: Type.Optional(Type.Array(TaskRelationSchema, { description: "Remove matching non-blocking relationships from this task" })),
+});
+
+type TaskCreateToolParams = { tasks?: TaskCreateInput[] } & Partial<TaskCreateInput>;
+type TaskUpdateToolParams = { updates?: Array<TaskUpdateFields & { taskId: string }>; taskId?: string } & TaskUpdateFields;
+
+function normalizeTaskCreateParams(params: TaskCreateToolParams): TaskCreateInput[] {
+  if (Array.isArray(params.tasks)) return params.tasks;
+  if (typeof params.subject !== "string" || typeof params.description !== "string") return [];
+  const { tasks: _tasks, ...task } = params;
+  return [task as TaskCreateInput];
+}
+
+function normalizeTaskUpdateParams(params: TaskUpdateToolParams): Array<TaskUpdateFields & { taskId: string }> {
+  if (Array.isArray(params.updates)) return params.updates;
+  if (typeof params.taskId !== "string") return [];
+  const { updates: _updates, ...update } = params;
+  return [update as TaskUpdateFields & { taskId: string }];
+}
+
+function formatRelations(relations: TaskRelation[]): string {
+  return relations.map(relation => `${relation.type} #${relation.target}`).join(", ");
 }
 
 /** Task tool names — used to detect task tool usage for reminder suppression. */
@@ -398,7 +456,7 @@ export default function (pi: ExtensionAPI) {
   pi.registerTool({
     name: "TaskCreate",
     label: "TaskCreate",
-    description: `Use this tool to create a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
+    description: `Use this tool to create one or more structured tasks for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.
 It also helps the user understand the progress of the task and overall progress of their requests.
 
 ## When to Use This Tool
@@ -409,10 +467,9 @@ Use this tool proactively in these scenarios:
 - Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
 - Plan mode - When using plan mode, create a task list to track the work
 - User explicitly requests todo list - When the user directly asks you to use the todo list
-- User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
+- User provides multiple tasks - Create the visible task set in one call
 - After receiving new instructions - Immediately capture user requirements as tasks
-- When you start working on a task - Mark it as in_progress BEFORE beginning work
-- After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation
+- After completing a task - Add any newly discovered follow-up tasks
 
 ## When NOT to Use This Tool
 
@@ -424,41 +481,50 @@ Skip using this tool when:
 
 NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
 
-## Task Fields
+## Parameters
 
-- **subject**: A brief, actionable title in imperative form (e.g., "Fix authentication bug in login flow")
-- **description**: Detailed description of what needs to be done, including context and acceptance criteria
-- **activeForm** (optional): Present continuous form shown in the spinner when the task is in_progress (e.g., "Fixing authentication bug"). If omitted, the spinner shows the subject instead.
+Pass \`tasks\`, an array of task objects. Use one element for a single task.
+
+Each task supports:
+- **key**: Temporary key for references inside this create call
+- **subject**: A brief, actionable title in imperative form
+- **description**: Detailed context and acceptance criteria
+- **activeForm**: Present continuous form shown in the spinner when in_progress
+- **agentType**: Agent type for subagent execution via TaskExecute
+- **metadata**: Arbitrary metadata
+- **blocks** / **blockedBy**: Hard dependencies using task IDs or keys from this call
+- **relations**: Non-blocking relationships, e.g. \`parent\`, \`related\`, \`validates\`, \`supersedes\`, or \`orderAfter\`
 
 All tasks are created with status \`pending\`.
 
 ## Tips
 
-- Create tasks with clear, specific subjects that describe the outcome
-- Include enough detail in the description for another agent to understand and complete the task
-- After creating tasks, use TaskUpdate to set up dependencies (blocks/blockedBy) if needed
-- Check TaskList first to avoid creating duplicate tasks
-- Include \`agentType\` (e.g., "general-purpose", "Explore") to mark tasks for subagent execution via TaskExecute`,
+- Create small, scan-friendly task sets instead of many separate tool calls
+- Use \`key\` plus \`blockedBy\` to create tasks and their hard dependencies atomically
+- Use \`relations\` for structure that should not block execution
+- Check TaskList first to avoid creating duplicate tasks`,
     promptGuidelines: [
       "When working on complex multi-step tasks, use TaskCreate to track progress and TaskUpdate to update status.",
       "Mark tasks as in_progress before starting work and completed when done.",
       "Use TaskList to check for available work after completing a task.",
     ],
     parameters: Type.Object({
-      subject: Type.String({ description: "A brief title for the task" }),
-      description: Type.String({ description: "A detailed description of what needs to be done" }),
-      activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in spinner when in_progress (e.g., 'Running tests')" })),
-      agentType: Type.Optional(Type.String({ description: "Agent type for subagent execution (e.g., 'general-purpose', 'Explore'). Tasks with agentType can be started via TaskExecute." })),
-      metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Arbitrary metadata to attach to the task" })),
+      tasks: Type.Array(TaskCreateItemSchema, { description: "Tasks to create. Use one element for a single task.", minItems: 1 }),
     }),
 
-    execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
+    execute(_toolCallId, params: TaskCreateToolParams, _signal, _onUpdate, _ctx) {
+      const inputs = normalizeTaskCreateParams(params);
+      if (inputs.length === 0) return Promise.resolve(textResult("No tasks provided"));
+
       autoClear.resetBatchCountdown();
-      const meta = params.metadata ?? {};
-      if (params.agentType) meta.agentType = params.agentType;
-      const task = store.create(params.subject, params.description, params.activeForm, Object.keys(meta).length > 0 ? meta : undefined);
+      const { tasks, warnings } = store.createMany(inputs);
       widget.update();
-      return Promise.resolve(textResult(`Task #${task.id} created successfully: ${task.subject}`));
+
+      const lines = tasks.length === 1
+        ? [`Task #${tasks[0].id} created successfully: ${tasks[0].subject}`]
+        : [`Created ${tasks.length} tasks:`, ...tasks.map(task => `#${task.id} ${task.subject}`)];
+      if (warnings.length > 0) lines.push(`Warnings: ${warnings.join("; ")}`);
+      return Promise.resolve(textResult(lines.join("\n")));
     },
   });
 
@@ -588,6 +654,9 @@ Returns full task details:
       if (task.blocks.length > 0) {
         lines.push(`Blocks: ${task.blocks.map(id => "#" + id).join(", ")}`);
       }
+      if (task.relations.length > 0) {
+        lines.push(`Relations: ${formatRelations(task.relations)}`);
+      }
 
       // Show metadata if non-empty
       const metaKeys = Object.keys(task.metadata);
@@ -606,7 +675,7 @@ Returns full task details:
   pi.registerTool({
     name: "TaskUpdate",
     label: "TaskUpdate",
-    description: `Use this tool to update a task in the task list.
+    description: `Use this tool to update one or more tasks in the task list.
 
 ## When to Use This Tool
 
@@ -621,110 +690,78 @@ Returns full task details:
 - After resolving, call TaskList to find your next task
 
 - ONLY mark a task as completed when you have FULLY accomplished it
-- If you encounter errors, blockers, or cannot finish, keep the task as in_progress
-- When blocked, create a new task describing what needs to be resolved
-- Never mark a task as completed if:
-  - Tests are failing
-  - Implementation is partial
-  - You encountered unresolved errors
-  - You couldn't find necessary files or dependencies
+- If you encounter errors, blockers, or cannot finish, keep it as in_progress
+- Never mark a task as completed if tests are failing, implementation is partial, or unresolved errors remain
 
 **Delete tasks:**
-- When a task is no longer relevant or was created in error
-- Setting status to \`deleted\` permanently removes the task
+- Include an update with \`status: "deleted"\` to permanently remove that task
+- Deleting a task cleans hard dependency edges and non-blocking relationships pointing to it
 
-**Update task details:**
-- When requirements change or become clearer
-- When establishing dependencies between tasks
+**Update task details and relationships:**
+- Use \`updates\`, an array of update objects. Use one element for a single task.
+- \`addBlocks\` and \`addBlockedBy\` are hard blocking dependencies and affect availability.
+- \`setRelations\`, \`addRelations\`, and \`removeRelations\` manage non-blocking structure such as \`parent\`, \`related\`, \`validates\`, \`supersedes\`, and \`orderAfter\`.
 
 ## Fields You Can Update
 
-- **status**: The task status (see Status Workflow below)
-- **subject**: Change the task title (imperative form, e.g., "Run tests")
-- **description**: Change the task description
-- **activeForm**: Present continuous form shown in spinner when in_progress (e.g., "Running tests")
-- **owner**: Change the task owner (agent name)
-- **metadata**: Merge metadata keys into the task (set a key to null to delete it)
-- **addBlocks**: Mark tasks that cannot start until this one completes
-- **addBlockedBy**: Mark tasks that must complete before this one can start
-
-## Status Workflow
-
-Status progresses: \`pending\` → \`in_progress\` → \`completed\`
-
-Use \`deleted\` to permanently remove a task.
-
-## Staleness
-
-Make sure to read a task's latest state using \`TaskGet\` before updating it.
+- **taskId**: Task to update
+- **status**: \`pending\`, \`in_progress\`, \`completed\`, or \`deleted\`
+- **subject**, **description**, **activeForm**, **owner**
+- **metadata**: Shallow merge; set a key to null to delete it
+- **addBlocks** / **addBlockedBy**: Hard dependencies
+- **setRelations** / **addRelations** / **removeRelations**: Non-blocking relationships
 
 ## Examples
 
-Mark task as in progress when starting work:
+Mark one task as in progress:
 \`\`\`json
-{"taskId": "1", "status": "in_progress"}
+{"updates": [{"taskId": "1", "status": "in_progress"}]}
 \`\`\`
 
-Mark task as completed after finishing work:
+Complete and delete tasks together:
 \`\`\`json
-{"taskId": "1", "status": "completed"}
+{"updates": [{"taskId": "1", "status": "completed"}, {"taskId": "2", "status": "deleted"}]}
 \`\`\`
 
-Delete a task:
+Add a soft ordering relationship:
 \`\`\`json
-{"taskId": "1", "status": "deleted"}
-\`\`\`
-
-Claim a task by setting owner:
-\`\`\`json
-{"taskId": "1", "owner": "my-name"}
-\`\`\`
-
-Set up task dependencies:
-\`\`\`json
-{"taskId": "2", "addBlockedBy": ["1"]}
+{"updates": [{"taskId": "3", "addRelations": [{"type": "orderAfter", "target": "1"}]}]}
 \`\`\``,
     parameters: Type.Object({
-      taskId: Type.String({ description: "The ID of the task to update" }),
-      status: Type.Optional(Type.Unsafe<"pending" | "in_progress" | "completed" | "deleted">({
-        type: "string",
-        enum: ["pending", "in_progress", "completed", "deleted"],
-        description: "New status for the task",
-      })),
-      subject: Type.Optional(Type.String({ description: "New subject for the task" })),
-      description: Type.Optional(Type.String({ description: "New description for the task" })),
-      activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in spinner when in_progress" })),
-      owner: Type.Optional(Type.String({ description: "New owner for the task" })),
-      metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Metadata keys to merge into the task. Set a key to null to delete it." })),
-      addBlocks: Type.Optional(Type.Array(Type.String(), { description: "Task IDs that this task blocks" })),
-      addBlockedBy: Type.Optional(Type.Array(Type.String(), { description: "Task IDs that block this task" })),
+      updates: Type.Array(TaskUpdateItemSchema, { description: "Task updates to apply. Use one element for a single task.", minItems: 1 }),
     }),
 
-    execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      const { taskId, ...fields } = params;
-      const { task, changedFields, warnings } = store.update(taskId, fields);
+    execute(_toolCallId, params: TaskUpdateToolParams, _signal, _onUpdate, _ctx) {
+      const updates = normalizeTaskUpdateParams(params);
+      if (updates.length === 0) return Promise.resolve(textResult("No task updates provided"));
 
-      if (changedFields.length === 0 && !task) {
-        return Promise.resolve(textResult(`Task #${taskId} not found`));
+      const { results, warnings } = store.updateMany(updates);
+      const lines: string[] = [];
+
+      for (let i = 0; i < updates.length; i++) {
+        const update = updates[i];
+        const result = results[i];
+        if (!result || (result.changedFields.length === 0 && !result.task)) {
+          lines.push(`Task #${update.taskId} not found`);
+          continue;
+        }
+
+        if (update.status === "in_progress") {
+          widget.setActiveTask(update.taskId);
+          autoClear.resetBatchCountdown();
+        } else if (update.status === "pending") {
+          autoClear.resetBatchCountdown();
+        } else if (update.status === "completed" || update.status === "deleted") {
+          widget.setActiveTask(update.taskId, false);
+          if (update.status === "completed") autoClear.trackCompletion(update.taskId, currentTurn);
+        }
+
+        lines.push(`Updated task #${update.taskId} ${result.changedFields.join(", ")}`);
       }
 
-      // Update widget active task tracking
-      if (fields.status === "in_progress") {
-        widget.setActiveTask(taskId);
-        autoClear.resetBatchCountdown();
-      } else if (fields.status === "pending") {
-        autoClear.resetBatchCountdown();
-      } else if (fields.status === "completed" || fields.status === "deleted") {
-        widget.setActiveTask(taskId, false);
-        if (fields.status === "completed") autoClear.trackCompletion(taskId, currentTurn);
-      }
-
+      if (warnings.length > 0) lines.push(`Warnings: ${warnings.join("; ")}`);
       widget.update();
-      let msg = `Updated task #${taskId} ${changedFields.join(", ")}`;
-      if (warnings.length > 0) {
-        msg += ` (warning: ${warnings.join("; ")})`;
-      }
-      return Promise.resolve(textResult(msg));
+      return Promise.resolve(textResult(lines.join("\n")));
     },
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -577,8 +577,7 @@ Use TaskGet with a specific task ID to view full details including description a
 
       const hierarchy = buildTaskHierarchy(tasks);
       const lines = flattenTaskHierarchy(hierarchy).map(row => {
-        const indent = row.depth > 0 ? `${"  ".repeat(row.depth)}↳ ` : "";
-        let line = `${indent}#${row.task.id} [${row.task.status}] ${row.task.subject}`;
+        let line = `${row.connectorPrefix}#${row.task.id} [${row.task.status}] ${row.task.subject}`;
 
         if (row.task.owner) {
           line += ` (${row.task.owner})`;

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -8,7 +8,16 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
-import type { Task, TaskStatus, TaskStoreData } from "./types.js";
+import type {
+  Task,
+  TaskCreateInput,
+  TaskCreateManyResult,
+  TaskMutationResult,
+  TaskRelation,
+  TaskStoreData,
+  TaskUpdateFields,
+  TaskUpdateManyResult,
+} from "./types.js";
 
 const TASKS_DIR = join(homedir(), ".pi", "tasks");
 const LOCK_RETRY_MS = 50;
@@ -30,10 +39,14 @@ function acquireLock(lockPath: string): void {
             unlinkSync(lockPath);
             continue;
           }
-        } catch { /* ignore read errors */ }
+        } catch {
+          /* ignore read errors */
+        }
         // Wait and retry
         const start = Date.now();
-        while (Date.now() - start < LOCK_RETRY_MS) { /* busy wait */ }
+        while (Date.now() - start < LOCK_RETRY_MS) {
+          /* busy wait */
+        }
         continue;
       }
       throw e;
@@ -43,11 +56,28 @@ function acquireLock(lockPath: string): void {
 }
 
 function releaseLock(lockPath: string): void {
-  try { unlinkSync(lockPath); } catch { /* ignore */ }
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    /* ignore */
+  }
 }
 
 function isProcessRunning(pid: number): boolean {
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function relationKey(relation: TaskRelation): string {
+  return `${relation.type}\0${relation.target}`;
+}
+
+function normalizeRelation(relation: TaskRelation): TaskRelation {
+  return { type: relation.type, target: relation.target };
 }
 
 export class TaskStore {
@@ -77,9 +107,17 @@ export class TaskStore {
       this.nextId = data.nextId;
       this.tasks.clear();
       for (const t of data.tasks) {
-        this.tasks.set(t.id, t);
+        this.tasks.set(t.id, {
+          ...t,
+          metadata: t.metadata ?? {},
+          blocks: t.blocks ?? [],
+          blockedBy: t.blockedBy ?? [],
+          relations: t.relations ?? [],
+        });
       }
-    } catch { /* corrupt file — start fresh */ }
+    } catch {
+      /* corrupt file — start fresh */
+    }
   }
 
   /** Write store to disk atomically (file-backed mode only). */
@@ -108,24 +146,202 @@ export class TaskStore {
     }
   }
 
+  private resolveRef(ref: string, keyMap?: Map<string, string>): string {
+    return keyMap?.get(ref) ?? ref;
+  }
+
+  private addBlockEdge(blockerId: string, blockedId: string, warnings: string[], cycleIds: [string, string] = [blockerId, blockedId]): void {
+    const blocker = this.tasks.get(blockerId);
+    const blocked = this.tasks.get(blockedId);
+
+    if (blocker && !blocker.blocks.includes(blockedId)) {
+      blocker.blocks.push(blockedId);
+      blocker.updatedAt = Date.now();
+    }
+    if (blocked && !blocked.blockedBy.includes(blockerId)) {
+      blocked.blockedBy.push(blockerId);
+      blocked.updatedAt = Date.now();
+    }
+
+    if (blockerId === blockedId) {
+      warnings.push(`#${blockerId} blocks itself`);
+    } else if (!blocker) {
+      warnings.push(`#${blockerId} does not exist`);
+    } else if (!blocked) {
+      warnings.push(`#${blockedId} does not exist`);
+    } else if (blocked.blocks.includes(blockerId)) {
+      warnings.push(`cycle: #${cycleIds[0]} and #${cycleIds[1]} block each other`);
+    }
+  }
+
+  private addRelation(task: Task, relation: TaskRelation, warnings: string[]): void {
+    const normalized = normalizeRelation(relation);
+    const key = relationKey(normalized);
+    if (task.relations.some(existing => relationKey(existing) === key)) return;
+    if (!this.tasks.has(normalized.target)) {
+      warnings.push(`relation target #${normalized.target} does not exist`);
+    }
+    task.relations.push(normalized);
+    task.updatedAt = Date.now();
+  }
+
+  private cleanupReferencesTo(id: string): void {
+    for (const t of this.tasks.values()) {
+      t.blocks = t.blocks.filter(bid => bid !== id);
+      t.blockedBy = t.blockedBy.filter(bid => bid !== id);
+      t.relations = t.relations.filter(rel => rel.target !== id);
+    }
+  }
+
+  private applyUpdate(id: string, fields: TaskUpdateFields): TaskMutationResult {
+    const task = this.tasks.get(id);
+    if (!task) return { task: undefined, changedFields: [], warnings: [] };
+
+    const changedFields: string[] = [];
+    const warnings: string[] = [];
+
+    // Handle deletion
+    if (fields.status === "deleted") {
+      this.tasks.delete(id);
+      this.cleanupReferencesTo(id);
+      return { task: undefined, changedFields: ["deleted"], warnings: [] };
+    }
+
+    if (fields.status !== undefined) {
+      task.status = fields.status;
+      changedFields.push("status");
+    }
+    if (fields.subject !== undefined) {
+      task.subject = fields.subject;
+      changedFields.push("subject");
+    }
+    if (fields.description !== undefined) {
+      task.description = fields.description;
+      changedFields.push("description");
+    }
+    if (fields.activeForm !== undefined) {
+      task.activeForm = fields.activeForm;
+      changedFields.push("activeForm");
+    }
+    if (fields.owner !== undefined) {
+      task.owner = fields.owner;
+      changedFields.push("owner");
+    }
+
+    // Metadata: shallow merge, null deletes keys
+    if (fields.metadata !== undefined) {
+      for (const [key, value] of Object.entries(fields.metadata)) {
+        if (value === null) {
+          delete task.metadata[key];
+        } else {
+          task.metadata[key] = value;
+        }
+      }
+      changedFields.push("metadata");
+    }
+
+    // Bidirectional dependency edges
+    if (fields.addBlocks && fields.addBlocks.length > 0) {
+      for (const targetId of fields.addBlocks) {
+        this.addBlockEdge(id, targetId, warnings);
+      }
+      changedFields.push("blocks");
+    }
+
+    if (fields.addBlockedBy && fields.addBlockedBy.length > 0) {
+      for (const targetId of fields.addBlockedBy) {
+        this.addBlockEdge(targetId, id, warnings, [id, targetId]);
+      }
+      changedFields.push("blockedBy");
+    }
+
+    if (fields.setRelations !== undefined) {
+      task.relations = [];
+      for (const relation of fields.setRelations) {
+        this.addRelation(task, relation, warnings);
+      }
+      changedFields.push("relations");
+    }
+
+    if (fields.addRelations && fields.addRelations.length > 0) {
+      for (const relation of fields.addRelations) {
+        this.addRelation(task, relation, warnings);
+      }
+      changedFields.push("relations");
+    }
+
+    if (fields.removeRelations && fields.removeRelations.length > 0) {
+      const removeKeys = new Set(fields.removeRelations.map(relation => relationKey(normalizeRelation(relation))));
+      task.relations = task.relations.filter(relation => !removeKeys.has(relationKey(relation)));
+      changedFields.push("relations");
+    }
+
+    task.updatedAt = Date.now();
+    return { task, changedFields, warnings };
+  }
+
   create(subject: string, description: string, activeForm?: string, metadata?: Record<string, any>): Task {
+    const result = this.createMany([{ subject, description, activeForm, metadata }]);
+    return result.tasks[0];
+  }
+
+  createMany(inputs: TaskCreateInput[]): TaskCreateManyResult {
     return this.withLock(() => {
-      const now = Date.now();
-      const task: Task = {
-        id: String(this.nextId++),
-        subject,
-        description,
-        status: "pending",
-        activeForm,
-        owner: undefined,
-        metadata: metadata ?? {},
-        blocks: [],
-        blockedBy: [],
-        createdAt: now,
-        updatedAt: now,
-      };
-      this.tasks.set(task.id, task);
-      return task;
+      const warnings: string[] = [];
+      const created: Task[] = [];
+      const keyMap = new Map<string, string>();
+
+      for (const input of inputs) {
+        const now = Date.now();
+        const metadata = { ...(input.metadata ?? {}) };
+        if (input.agentType) metadata.agentType = input.agentType;
+        const task: Task = {
+          id: String(this.nextId++),
+          subject: input.subject,
+          description: input.description,
+          status: "pending",
+          activeForm: input.activeForm,
+          owner: undefined,
+          metadata,
+          blocks: [],
+          blockedBy: [],
+          relations: [],
+          createdAt: now,
+          updatedAt: now,
+        };
+        this.tasks.set(task.id, task);
+        created.push(task);
+
+        if (input.key) {
+          if (keyMap.has(input.key)) {
+            warnings.push(`duplicate task key "${input.key}"`);
+          } else {
+            keyMap.set(input.key, task.id);
+          }
+        }
+      }
+
+      for (let i = 0; i < inputs.length; i++) {
+        const input = inputs[i];
+        const task = created[i];
+
+        for (const targetRef of input.blocks ?? []) {
+          this.addBlockEdge(task.id, this.resolveRef(targetRef, keyMap), warnings);
+        }
+
+        for (const targetRef of input.blockedBy ?? []) {
+          this.addBlockEdge(this.resolveRef(targetRef, keyMap), task.id, warnings, [task.id, this.resolveRef(targetRef, keyMap)]);
+        }
+
+        for (const relation of input.relations ?? []) {
+          this.addRelation(task, {
+            ...relation,
+            target: this.resolveRef(relation.target, keyMap),
+          }, warnings);
+        }
+      }
+
+      return { tasks: created, warnings };
     });
   }
 
@@ -140,114 +356,18 @@ export class TaskStore {
     return Array.from(this.tasks.values()).sort((a, b) => Number(a.id) - Number(b.id));
   }
 
-  update(id: string, fields: {
-    status?: TaskStatus | "deleted";
-    subject?: string;
-    description?: string;
-    activeForm?: string;
-    owner?: string;
-    metadata?: Record<string, any>;
-    addBlocks?: string[];
-    addBlockedBy?: string[];
-  }): { task: Task | undefined; changedFields: string[]; warnings: string[] } {
+  update(id: string, fields: TaskUpdateFields): TaskMutationResult {
+    const result = this.updateMany([{ taskId: id, ...fields }]);
+    return result.results[0] ?? { task: undefined, changedFields: [], warnings: result.warnings };
+  }
+
+  updateMany(updates: Array<TaskUpdateFields & { taskId: string }>): TaskUpdateManyResult {
     return this.withLock(() => {
-      const task = this.tasks.get(id);
-      if (!task) return { task: undefined, changedFields: [], warnings: [] };
-
-      const changedFields: string[] = [];
-      const warnings: string[] = [];
-
-      // Handle deletion
-      if (fields.status === "deleted") {
-        this.tasks.delete(id);
-        // Clean up dependency edges pointing to this task
-        for (const t of this.tasks.values()) {
-          t.blocks = t.blocks.filter(bid => bid !== id);
-          t.blockedBy = t.blockedBy.filter(bid => bid !== id);
-        }
-        return { task: undefined, changedFields: ["deleted"], warnings: [] };
-      }
-
-      if (fields.status !== undefined) {
-        task.status = fields.status;
-        changedFields.push("status");
-      }
-      if (fields.subject !== undefined) {
-        task.subject = fields.subject;
-        changedFields.push("subject");
-      }
-      if (fields.description !== undefined) {
-        task.description = fields.description;
-        changedFields.push("description");
-      }
-      if (fields.activeForm !== undefined) {
-        task.activeForm = fields.activeForm;
-        changedFields.push("activeForm");
-      }
-      if (fields.owner !== undefined) {
-        task.owner = fields.owner;
-        changedFields.push("owner");
-      }
-
-      // Metadata: shallow merge, null deletes keys
-      if (fields.metadata !== undefined) {
-        for (const [key, value] of Object.entries(fields.metadata)) {
-          if (value === null) {
-            delete task.metadata[key];
-          } else {
-            task.metadata[key] = value;
-          }
-        }
-        changedFields.push("metadata");
-      }
-
-      // Bidirectional dependency edges
-      if (fields.addBlocks && fields.addBlocks.length > 0) {
-        for (const targetId of fields.addBlocks) {
-          if (!task.blocks.includes(targetId)) {
-            task.blocks.push(targetId);
-          }
-          const target = this.tasks.get(targetId);
-          if (target && !target.blockedBy.includes(id)) {
-            target.blockedBy.push(id);
-            target.updatedAt = Date.now();
-          }
-          // Warnings for problematic edges
-          if (targetId === id) {
-            warnings.push(`#${id} blocks itself`);
-          } else if (!target) {
-            warnings.push(`#${targetId} does not exist`);
-          } else if (target.blocks.includes(id)) {
-            warnings.push(`cycle: #${id} and #${targetId} block each other`);
-          }
-        }
-        changedFields.push("blocks");
-      }
-
-      if (fields.addBlockedBy && fields.addBlockedBy.length > 0) {
-        for (const targetId of fields.addBlockedBy) {
-          if (!task.blockedBy.includes(targetId)) {
-            task.blockedBy.push(targetId);
-          }
-          const target = this.tasks.get(targetId);
-          if (target && !target.blocks.includes(id)) {
-            target.blocks.push(id);
-            target.updatedAt = Date.now();
-          }
-          // Warnings for problematic edges
-          if (targetId === id) {
-            warnings.push(`#${id} blocks itself`);
-          } else if (!target) {
-            warnings.push(`#${targetId} does not exist`);
-          } else if (task.blocks.includes(targetId)) {
-            warnings.push(`cycle: #${id} and #${targetId} block each other`);
-          }
-        }
-        changedFields.push("blockedBy");
-      }
-
-      task.updatedAt = Date.now();
-      return { task, changedFields, warnings };
+      const results = updates.map(({ taskId, ...fields }) => this.applyUpdate(taskId, fields));
+      return {
+        results,
+        warnings: results.flatMap(result => result.warnings),
+      };
     });
   }
 
@@ -256,11 +376,7 @@ export class TaskStore {
     return this.withLock(() => {
       if (!this.tasks.has(id)) return false;
       this.tasks.delete(id);
-      // Clean up dependency edges
-      for (const t of this.tasks.values()) {
-        t.blocks = t.blocks.filter(bid => bid !== id);
-        t.blockedBy = t.blockedBy.filter(bid => bid !== id);
-      }
+      this.cleanupReferencesTo(id);
       return true;
     });
   }
@@ -277,7 +393,11 @@ export class TaskStore {
   /** Delete the backing file (if file-backed and empty). */
   deleteFileIfEmpty(): boolean {
     if (!this.filePath || this.tasks.size > 0) return false;
-    try { unlinkSync(this.filePath); } catch { /* ignore */ }
+    try {
+      unlinkSync(this.filePath);
+    } catch {
+      /* ignore */
+    }
     return true;
   }
 
@@ -291,12 +411,13 @@ export class TaskStore {
           count++;
         }
       }
-      // Clean up dependency edges for deleted tasks
+      // Clean up dependency edges and relationships for deleted tasks
       if (count > 0) {
         const validIds = new Set(this.tasks.keys());
         for (const t of this.tasks.values()) {
           t.blocks = t.blocks.filter(bid => validIds.has(bid));
           t.blockedBy = t.blockedBy.filter(bid => validIds.has(bid));
+          t.relations = t.relations.filter(relation => validIds.has(relation.target));
         }
       }
       return count;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,55 @@
 
 export type TaskStatus = "pending" | "in_progress" | "completed";
 
+export type TaskRelationType = "parent" | "related" | "validates" | "supersedes" | "orderAfter" | (string & {});
+
+export interface TaskRelation {
+  type: TaskRelationType;
+  target: string;
+}
+
+export interface TaskCreateInput {
+  key?: string;
+  subject: string;
+  description: string;
+  activeForm?: string;
+  agentType?: string;
+  metadata?: Record<string, any>;
+  blocks?: string[];
+  blockedBy?: string[];
+  relations?: TaskRelation[];
+}
+
+export interface TaskUpdateFields {
+  status?: TaskStatus | "deleted";
+  subject?: string;
+  description?: string;
+  activeForm?: string;
+  owner?: string;
+  metadata?: Record<string, any>;
+  addBlocks?: string[];
+  addBlockedBy?: string[];
+  setRelations?: TaskRelation[];
+  addRelations?: TaskRelation[];
+  removeRelations?: TaskRelation[];
+}
+
+export interface TaskMutationResult {
+  task: Task | undefined;
+  changedFields: string[];
+  warnings: string[];
+}
+
+export interface TaskCreateManyResult {
+  tasks: Task[];
+  warnings: string[];
+}
+
+export interface TaskUpdateManyResult {
+  results: TaskMutationResult[];
+  warnings: string[];
+}
+
 export interface Task {
   id: string;
   subject: string;
@@ -14,6 +63,7 @@ export interface Task {
   metadata: Record<string, any>;
   blocks: string[];
   blockedBy: string[];
+  relations: TaskRelation[];
   createdAt: number;
   updatedAt: number;
 }

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -9,6 +9,12 @@
  */
 
 import { truncateToWidth } from "@mariozechner/pi-tui";
+import {
+  buildTaskHierarchy,
+  flattenTaskHierarchy,
+  formatTaskRefs,
+  getOpenBlockerIds,
+} from "../hierarchy.js";
 import type { TaskStore } from "../task-store.js";
 
 // ---- Types ----
@@ -137,10 +143,13 @@ export class TaskWidget {
     const spinnerChar = SPINNER[this.widgetFrame % SPINNER.length];
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
-    const visible = tasks.slice(0, MAX_VISIBLE_TASKS);
-    for (let i = 0; i < visible.length; i++) {
-      const task = visible[i];
+    const hierarchy = buildTaskHierarchy(tasks);
+    const rows = flattenTaskHierarchy(hierarchy);
+    const visible = rows.slice(0, MAX_VISIBLE_TASKS);
+    for (const row of visible) {
+      const task = row.task;
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";
+      const indent = "  ".repeat(row.depth);
 
       let icon: string;
       if (isActive) {
@@ -153,16 +162,17 @@ export class TaskWidget {
         icon = "◻";
       }
 
-      let suffix = "";
-      if (task.status === "pending" && task.blockedBy.length > 0) {
-        const openBlockers = task.blockedBy.filter(bid => {
-          const blocker = this.store.get(bid);
-          return blocker && blocker.status !== "completed";
-        });
-        if (openBlockers.length > 0) {
-          suffix = theme.fg("dim", ` › blocked by ${openBlockers.map(id => "#" + id).join(", ")}`);
-        }
+      const suffixParts: string[] = [];
+      if (row.summary.total > 0) {
+        suffixParts.push(`${row.summary.completed}/${row.summary.total} subtasks`);
+        if (row.readyToComplete) suffixParts.push("ready to complete");
+        if (row.availableChildIds.length > 1) suffixParts.push(`parallel ${formatTaskRefs(row.availableChildIds)}`);
       }
+      const openBlockers = getOpenBlockerIds(task, hierarchy);
+      if (task.status === "pending" && openBlockers.length > 0) {
+        suffixParts.push(`blocked by ${formatTaskRefs(openBlockers)}`);
+      }
+      const suffix = suffixParts.length > 0 ? theme.fg("dim", ` › ${suffixParts.join(" · ")}`) : "";
 
       let text: string;
       if (isActive) {
@@ -180,21 +190,21 @@ export class TaskWidget {
             ? ` ${theme.fg("dim", `(${elapsed} · ${tokenParts.join(" ")})`)}`
             : ` ${theme.fg("dim", `(${elapsed})`)}`;
         }
-        text = `  ${icon} ${theme.fg("dim", "#" + task.id)} ${theme.fg("accent", form + agentLabel + "…")}${stats}`;
+        text = `  ${indent}${icon} ${theme.fg("dim", "#" + task.id)} ${theme.fg("accent", form + agentLabel + "…")}${stats}`;
       } else if (task.status === "completed") {
-        text = `  ${icon} ${theme.fg("dim", theme.strikethrough("#" + task.id + " " + task.subject))}`;
+        text = `  ${indent}${icon} ${theme.fg("dim", theme.strikethrough("#" + task.id + " " + task.subject))}`;
       } else {
         const agentSuffix = task.status === "in_progress" && task.metadata?.agentId
           ? theme.fg("dim", ` (agent ${task.metadata.agentId.slice(0, 5)})`)
           : "";
-        text = `  ${icon} ${theme.fg("dim", "#" + task.id)} ${task.subject}${agentSuffix}`;
+        text = `  ${indent}${icon} ${theme.fg("dim", "#" + task.id)} ${task.subject}${agentSuffix}`;
       }
 
       lines.push(truncate(text + suffix));
     }
 
-    if (tasks.length > MAX_VISIBLE_TASKS) {
-      lines.push(truncate(theme.fg("dim", `    … and ${tasks.length - MAX_VISIBLE_TASKS} more`)));
+    if (rows.length > MAX_VISIBLE_TASKS) {
+      lines.push(truncate(theme.fg("dim", `    … and ${rows.length - MAX_VISIBLE_TASKS} more`)));
     }
 
     return lines;

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -5,7 +5,7 @@
  *   ✔ completed tasks (strikethrough + dim)
  *   ◼ in_progress tasks
  *   ◻ pending tasks
- *   ◐/◓/◑/◒ actively executing task (spinner with activeForm text)
+ *   ⠋/⠙/⠹/⠸ actively executing task (spinner with activeForm text)
  */
 
 import { truncateToWidth } from "@mariozechner/pi-tui";
@@ -34,9 +34,9 @@ export type UICtx = {
   ): void;
 };
 
-/** Uniform-width spinner frames for animated active task indicators. */
-const SPINNER = ["◐", "◓", "◑", "◒"];
-const SPINNER_INTERVAL_MS = 250;
+/** Pi-style braille spinner frames for animated active task indicators. */
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_INTERVAL_MS = 180;
 
 const MAX_VISIBLE_TASKS = 10;
 

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -5,7 +5,7 @@
  *   ✔ completed tasks (strikethrough + dim)
  *   ◼ in_progress tasks
  *   ◻ pending tasks
- *   ✳/✽ actively executing task (star spinner with activeForm text)
+ *   ◐/◓/◑/◒ actively executing task (spinner with activeForm text)
  */
 
 import { truncateToWidth } from "@mariozechner/pi-tui";
@@ -34,8 +34,9 @@ export type UICtx = {
   ): void;
 };
 
-/** Star spinner frames for animated active task indicator (matches Claude Code). */
-const SPINNER = ["✳", "✴", "✵", "✶", "✷", "✸", "✹", "✺", "✻", "✼", "✽"];
+/** Uniform-width spinner frames for animated active task indicators. */
+const SPINNER = ["◐", "◓", "◑", "◒"];
+const SPINNER_INTERVAL_MS = 250;
 
 const MAX_VISIBLE_TASKS = 10;
 
@@ -118,7 +119,7 @@ export class TaskWidget {
   /** Ensure the widget update timer is running. */
   ensureTimer() {
     if (!this.widgetInterval) {
-      this.widgetInterval = setInterval(() => this.update(), 150);
+      this.widgetInterval = setInterval(() => this.update(), SPINNER_INTERVAL_MS);
     }
   }
 

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -149,7 +149,6 @@ export class TaskWidget {
     for (const row of visible) {
       const task = row.task;
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";
-      const indent = "  ".repeat(row.depth);
 
       let icon: string;
       if (isActive) {
@@ -190,14 +189,14 @@ export class TaskWidget {
             ? ` ${theme.fg("dim", `(${elapsed} · ${tokenParts.join(" ")})`)}`
             : ` ${theme.fg("dim", `(${elapsed})`)}`;
         }
-        text = `  ${indent}${icon} ${theme.fg("dim", "#" + task.id)} ${theme.fg("accent", form + agentLabel + "…")}${stats}`;
+        text = `  ${row.connectorPrefix}${icon} ${theme.fg("dim", "#" + task.id)} ${theme.fg("accent", form + agentLabel + "…")}${stats}`;
       } else if (task.status === "completed") {
-        text = `  ${indent}${icon} ${theme.fg("dim", theme.strikethrough("#" + task.id + " " + task.subject))}`;
+        text = `  ${row.connectorPrefix}${icon} ${theme.fg("dim", theme.strikethrough("#" + task.id + " " + task.subject))}`;
       } else {
         const agentSuffix = task.status === "in_progress" && task.metadata?.agentId
           ? theme.fg("dim", ` (agent ${task.metadata.agentId.slice(0, 5)})`)
           : "";
-        text = `  ${indent}${icon} ${theme.fg("dim", "#" + task.id)} ${task.subject}${agentSuffix}`;
+        text = `  ${row.connectorPrefix}${icon} ${theme.fg("dim", "#" + task.id)} ${task.subject}${agentSuffix}`;
       }
 
       lines.push(truncate(text + suffix));

--- a/test/hierarchy.test.ts
+++ b/test/hierarchy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildTaskHierarchy, flattenTaskHierarchy } from "../src/hierarchy.js";
+import { TaskStore } from "../src/task-store.js";
+
+describe("task hierarchy", () => {
+  it("formats nested connector prefixes", () => {
+    const store = new TaskStore();
+    store.createMany([
+      { key: "root", subject: "Root", description: "Desc" },
+      { key: "first", subject: "First", description: "Desc", relations: [{ type: "parent", target: "root" }] },
+      { key: "grandchild", subject: "Grandchild", description: "Desc", relations: [{ type: "parent", target: "first" }] },
+      { key: "second", subject: "Second", description: "Desc", relations: [{ type: "parent", target: "root" }] },
+    ]);
+
+    const rows = flattenTaskHierarchy(buildTaskHierarchy(store.list()));
+
+    expect(rows.map(row => `${row.connectorPrefix}#${row.task.id}`)).toEqual([
+      "#1",
+      "├─ #2",
+      "│  └─ #3",
+      "└─ #4",
+    ]);
+  });
+});

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -503,6 +503,48 @@ describe("Standalone operation (no subagents extension)", () => {
     expect(result.content[0].text).toContain("in_progress");
   });
 
+  it("TaskCreate creates a keyed task batch", async () => {
+    const result = await mock.executeTool("TaskCreate", {
+      tasks: [
+        { key: "design", subject: "Design API", description: "Decide shape" },
+        {
+          key: "docs",
+          subject: "Document API",
+          description: "Write usage notes",
+          blockedBy: ["design"],
+          relations: [{ type: "validates", target: "design" }],
+        },
+      ],
+    });
+
+    expect(result.content[0].text).toContain("Created 2 tasks");
+    const task = await mock.executeTool("TaskGet", { taskId: "2" });
+    expect(task.content[0].text).toContain("Blocked by: #1");
+    expect(task.content[0].text).toContain("Relations: validates #1");
+  });
+
+  it("TaskUpdate applies an update batch", async () => {
+    await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "Finish me", description: "desc" },
+        { subject: "Remove me", description: "desc" },
+      ],
+    });
+
+    const result = await mock.executeTool("TaskUpdate", {
+      updates: [
+        { taskId: "1", status: "completed" },
+        { taskId: "2", status: "deleted" },
+      ],
+    });
+
+    expect(result.content[0].text).toContain("Updated task #1 status");
+    expect(result.content[0].text).toContain("Updated task #2 deleted");
+    const list = await mock.executeTool("TaskList", {});
+    expect(list.content[0].text).toContain("#1 [completed]");
+    expect(list.content[0].text).not.toContain("#2");
+  });
+
   it("TaskExecute gracefully refuses without subagents", async () => {
     await mock.executeTool("TaskCreate", {
       subject: "Agent task",

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -545,6 +545,37 @@ describe("Standalone operation (no subagents extension)", () => {
     expect(list.content[0].text).not.toContain("#2");
   });
 
+  it("TaskList and TaskGet expose hierarchy and parallel subtasks", async () => {
+    await mock.executeTool("TaskCreate", {
+      tasks: [
+        { key: "feature", subject: "Ship feature", description: "Parent container" },
+        { key: "api", subject: "Build API", description: "API work", relations: [{ type: "parent", target: "feature" }] },
+        { key: "docs", subject: "Write docs", description: "Docs work", relations: [{ type: "parent", target: "feature" }] },
+      ],
+    });
+
+    const list = await mock.executeTool("TaskList", {});
+    expect(list.content[0].text).toContain("#1 [pending] Ship feature [container 0/2 done] [parallel #2, #3]");
+    expect(list.content[0].text).toContain("  ↳ #2 [pending] Build API");
+
+    const parent = await mock.executeTool("TaskGet", { taskId: "1" });
+    expect(parent.content[0].text).toContain("Subtasks: #2, #3");
+    expect(parent.content[0].text).toContain("Subtask progress: 0/2 completed");
+    expect(parent.content[0].text).toContain("Available parallel subtasks: #2, #3");
+
+    const child = await mock.executeTool("TaskGet", { taskId: "2" });
+    expect(child.content[0].text).toContain("Parent: #1");
+    expect(child.content[0].text).toContain("Parallel siblings: #3");
+
+    const done = await mock.executeTool("TaskUpdate", {
+      updates: [
+        { taskId: "2", status: "completed" },
+        { taskId: "3", status: "completed" },
+      ],
+    });
+    expect(done.content[0].text).toContain("Ready to complete: #1 (2/2 subtasks done)");
+  });
+
   it("TaskExecute gracefully refuses without subagents", async () => {
     await mock.executeTool("TaskCreate", {
       subject: "Agent task",

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -556,7 +556,8 @@ describe("Standalone operation (no subagents extension)", () => {
 
     const list = await mock.executeTool("TaskList", {});
     expect(list.content[0].text).toContain("#1 [pending] Ship feature [container 0/2 done] [parallel #2, #3]");
-    expect(list.content[0].text).toContain("  ↳ #2 [pending] Build API");
+    expect(list.content[0].text).toContain("├─ #2 [pending] Build API");
+    expect(list.content[0].text).toContain("└─ #3 [pending] Write docs");
 
     const parent = await mock.executeTool("TaskGet", { taskId: "1" });
     expect(parent.content[0].text).toContain("Subtasks: #2, #3");

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -262,6 +262,56 @@ describe("TaskStore (in-memory)", () => {
     expect(store.get("3")!.blockedBy).toContain("1");
   });
 
+  it("creates multiple tasks with key-resolved dependencies and relations", () => {
+    const { tasks, warnings } = store.createMany([
+      { key: "design", subject: "Design API", description: "Decide shape" },
+      {
+        key: "implement",
+        subject: "Implement API",
+        description: "Build it",
+        blockedBy: ["design"],
+        relations: [{ type: "validates", target: "design" }],
+      },
+    ]);
+
+    expect(warnings).toEqual([]);
+    expect(tasks.map(t => t.id)).toEqual(["1", "2"]);
+    expect(store.get("1")!.blocks).toEqual(["2"]);
+    expect(store.get("2")!.blockedBy).toEqual(["1"]);
+    expect(store.get("2")!.relations).toEqual([{ type: "validates", target: "1" }]);
+  });
+
+  it("updates multiple tasks and deletes relationship references atomically", () => {
+    store.createMany([
+      { key: "parent", subject: "Parent", description: "Desc", relations: [{ type: "related", target: "child" }] },
+      { key: "child", subject: "Child", description: "Desc" },
+    ]);
+
+    const result = store.updateMany([
+      { taskId: "1", status: "completed" },
+      { taskId: "2", status: "deleted" },
+    ]);
+
+    expect(result.results.map(r => r.changedFields)).toEqual([["status"], ["deleted"]]);
+    expect(store.get("1")!.status).toBe("completed");
+    expect(store.get("1")!.relations).toEqual([]);
+    expect(store.get("2")).toBeUndefined();
+  });
+
+  it("deduplicates relations and warns on dangling relation targets", () => {
+    store.create("Task", "Desc");
+
+    const { warnings } = store.update("1", {
+      addRelations: [
+        { type: "related", target: "999" },
+        { type: "related", target: "999" },
+      ],
+    });
+
+    expect(store.get("1")!.relations).toEqual([{ type: "related", target: "999" }]);
+    expect(warnings).toEqual(["relation target #999 does not exist"]);
+  });
+
   it("addBlockedBy warns on self-dependency", () => {
     store.create("Self", "Desc");
     const { warnings } = store.update("1", { addBlockedBy: ["1"] });

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -134,6 +134,25 @@ describe("TaskWidget", () => {
     expect(blockedLine).not.toContain("blocked by");
   });
 
+  it("renders hierarchy with parent progress and parallel children", () => {
+    store.createMany([
+      { key: "feature", subject: "Feature", description: "Parent" },
+      { key: "api", subject: "API", description: "API work", relations: [{ type: "parent", target: "feature" }] },
+      { key: "docs", subject: "Docs", description: "Docs work", relations: [{ type: "parent", target: "feature" }] },
+      { key: "tests", subject: "Tests", description: "Test work", relations: [{ type: "parent", target: "feature" }] },
+    ]);
+    store.update("2", { status: "completed" });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    const parentLine = lines.find(l => l.includes("Feature"));
+    expect(parentLine).toContain("1/3 subtasks");
+    expect(parentLine).toContain("parallel #3, #4");
+
+    const childLine = lines.find(l => l.includes("Docs"));
+    expect(childLine).toMatch(/^\s{4}/);
+  });
+
   it("shows status summary in header", () => {
     store.create("Task A", "Desc");
     store.create("Task B", "Desc");

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -150,7 +150,7 @@ describe("TaskWidget", () => {
     expect(parentLine).toContain("parallel #3, #4");
 
     const childLine = lines.find(l => l.includes("Docs"));
-    expect(childLine).toMatch(/^\s{4}/);
+    expect(childLine).toContain("├─");
   });
 
   it("shows status summary in header", () => {

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -107,7 +107,8 @@ describe("TaskWidget", () => {
     const lines = renderWidget(ui.state);
     // Should show activeForm text with "…" suffix
     expect(lines[1]).toContain("Processing data…");
-    // Should NOT show ◼ for active task
+    // Should show a uniform spinner frame, not the static in-progress icon
+    expect(lines[1]).toMatch(/[◐◓◑◒]/);
     expect(lines[1]).not.toContain("◼");
   });
 

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -107,8 +107,8 @@ describe("TaskWidget", () => {
     const lines = renderWidget(ui.state);
     // Should show activeForm text with "…" suffix
     expect(lines[1]).toContain("Processing data…");
-    // Should show a uniform spinner frame, not the static in-progress icon
-    expect(lines[1]).toMatch(/[◐◓◑◒]/);
+    // Should show a braille spinner frame, not the static in-progress icon
+    expect(lines[1]).toMatch(/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/);
     expect(lines[1]).not.toContain("◼");
   });
 


### PR DESCRIPTION
Model task creation and updates as batch-capable store operations, with the existing single-task helpers normalized through the same paths. TaskCreate now accepts keyed task batches that can define hard dependencies and non-blocking relations atomically, while TaskUpdate accepts update batches including deletion and relation edits.

This adds persisted relation data, cleanup on deletion/completion, tool/docs coverage, and tests for keyed dependency resolution and multi-update behavior.

Validation: npm run typecheck; npm run lint; npm run test; npm run build; git diff --check.