### PR TITLE
Add configurable widget display settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export default function (pi: ExtensionAPI) {
   // For session scope, start with in-memory and upgrade once we have the session ID.
   let store = new TaskStore(resolveStorePath());
   const tracker = new ProcessTracker();
-  const widget = new TaskWidget(store);
+  const widget = new TaskWidget(store, cfg);
 
   // ── Subagent integration state ──
   /** Latest ExtensionContext — refreshed on every tool execution so cascade always has a valid one. */

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -10,6 +10,17 @@ import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
 import type { Task, TaskStatus, TaskStoreData } from "./types.js";
 
+function sortById(a: Task, b: Task): number {
+  return Number(a.id) - Number(b.id);
+}
+
+function sortByStatus(a: Task, b: Task): number {
+  const rank = (s: string) => s === "completed" ? 0 : s === "in_progress" ? 1 : 2;
+  return rank(a.status) - rank(b.status) || Number(a.id) - Number(b.id);
+}
+
+const SORT_FNS = { id: sortById, status: sortByStatus };
+
 const TASKS_DIR = join(homedir(), ".pi", "tasks");
 const LOCK_RETRY_MS = 50;
 const LOCK_MAX_RETRIES = 100; // 5s max
@@ -134,10 +145,10 @@ export class TaskStore {
     return this.tasks.get(id);
   }
 
-  /** List all tasks sorted by ID ascending. */
-  list(): Task[] {
+  /** List all tasks, sorted by the given order (defaults to ID ascending). */
+  list(sortOrder: "id" | "status" = "id"): Task[] {
     if (this.filePath) this.load();
-    return Array.from(this.tasks.values()).sort((a, b) => Number(a.id) - Number(b.id));
+    return Array.from(this.tasks.values()).sort(SORT_FNS[sortOrder]);
   }
 
   update(id: string, fields: {

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -19,7 +19,15 @@ function sortByStatus(a: Task, b: Task): number {
   return rank(a.status) - rank(b.status) || Number(a.id) - Number(b.id);
 }
 
-const SORT_FNS = { id: sortById, status: sortByStatus };
+function sortByRecent(a: Task, b: Task): number {
+  return b.updatedAt - a.updatedAt || Number(b.id) - Number(a.id);
+}
+
+function sortByOldest(a: Task, b: Task): number {
+  return a.updatedAt - b.updatedAt || Number(a.id) - Number(b.id);
+}
+
+const SORT_FNS = { id: sortById, status: sortByStatus, recent: sortByRecent, oldest: sortByOldest };
 
 const TASKS_DIR = join(homedir(), ".pi", "tasks");
 const LOCK_RETRY_MS = 50;
@@ -146,7 +154,7 @@ export class TaskStore {
   }
 
   /** List all tasks, sorted by the given order (defaults to ID ascending). */
-  list(sortOrder: "id" | "status" = "id"): Task[] {
+  list(sortOrder: "id" | "status" | "recent" | "oldest" = "id"): Task[] {
     if (this.filePath) this.load();
     return Array.from(this.tasks.values()).sort(SORT_FNS[sortOrder]);
   }

--- a/src/tasks-config.ts
+++ b/src/tasks-config.ts
@@ -10,6 +10,7 @@ export interface TasksConfig {
   showAll?: boolean;                     // default: false
   maxVisible?: number;                   // default: 10
   sortOrder?: "id" | "status" | "recent" | "oldest";  // default: "id"
+  hiddenAt?: "top" | "bottom";                         // default: "bottom"
 }
 
 const CONFIG_PATH = join(process.cwd(), ".pi", "tasks-config.json");

--- a/src/tasks-config.ts
+++ b/src/tasks-config.ts
@@ -9,6 +9,7 @@ export interface TasksConfig {
   autoClearCompleted?: "never" | "on_list_complete" | "on_task_complete";  // default: "on_list_complete"
   showAll?: boolean;                     // default: false
   maxVisible?: number;                   // default: 10
+  sortOrder?: "id" | "status";            // default: "id"
 }
 
 const CONFIG_PATH = join(process.cwd(), ".pi", "tasks-config.json");

--- a/src/tasks-config.ts
+++ b/src/tasks-config.ts
@@ -8,6 +8,7 @@ export interface TasksConfig {
   autoCascade?: boolean;   // default: false
   autoClearCompleted?: "never" | "on_list_complete" | "on_task_complete";  // default: "on_list_complete"
   showAll?: boolean;                     // default: false
+  maxVisible?: number;                   // default: 10
 }
 
 const CONFIG_PATH = join(process.cwd(), ".pi", "tasks-config.json");

--- a/src/tasks-config.ts
+++ b/src/tasks-config.ts
@@ -9,7 +9,7 @@ export interface TasksConfig {
   autoClearCompleted?: "never" | "on_list_complete" | "on_task_complete";  // default: "on_list_complete"
   showAll?: boolean;                     // default: false
   maxVisible?: number;                   // default: 10
-  sortOrder?: "id" | "status";            // default: "id"
+  sortOrder?: "id" | "status" | "recent" | "oldest";  // default: "id"
 }
 
 const CONFIG_PATH = join(process.cwd(), ".pi", "tasks-config.json");

--- a/src/tasks-config.ts
+++ b/src/tasks-config.ts
@@ -7,6 +7,7 @@ export interface TasksConfig {
   taskScope?: "memory" | "session" | "project";  // default: "session"
   autoCascade?: boolean;   // default: false
   autoClearCompleted?: "never" | "on_list_complete" | "on_task_complete";  // default: "on_list_complete"
+  showAll?: boolean;                     // default: false
 }
 
 const CONFIG_PATH = join(process.cwd(), ".pi", "tasks-config.json");

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -50,6 +50,15 @@ export async function openSettingsMenu(
         values: ["on", "off"],
       },
       {
+        id: "showAll",
+        label: "Show all tasks in widget",
+        description:
+          "When ON, every task is shown regardless of the visible limit. " +
+          "When OFF, the list is capped by 'Max visible tasks'.",
+        currentValue: (cfg.showAll ?? false) ? "on" : "off",
+        values: ["on", "off"],
+      },
+      {
         id: "autoClearCompleted",
         label: "Auto-clear completed tasks",
         description:
@@ -77,6 +86,10 @@ export async function openSettingsMenu(
         }
         if (id === "autoClearCompleted") {
           cfg.autoClearCompleted = newValue as TasksConfig["autoClearCompleted"];
+          saveTasksConfig(cfg);
+        }
+        if (id === "showAll") {
+          cfg.showAll = newValue === "on";
           saveTasksConfig(cfg);
         }
       },

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -74,7 +74,7 @@ export async function openSettingsMenu(
           '"status" groups by completed → in-progress → pending. ' +
           '"id" sorts by creation order.',
         currentValue: cfg.sortOrder ?? "id",
-        values: ["id", "status"],
+        values: ["id", "status", "recent", "oldest"],
       },
       {
         id: "autoClearCompleted",
@@ -115,7 +115,7 @@ export async function openSettingsMenu(
           saveTasksConfig(cfg);
         }
         if (id === "sortOrder") {
-          cfg.sortOrder = newValue as "id" | "status";
+          cfg.sortOrder = newValue as TasksConfig["sortOrder"];
           saveTasksConfig(cfg);
         }
       },

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -77,6 +77,15 @@ export async function openSettingsMenu(
         values: ["id", "status", "recent", "oldest"],
       },
       {
+        id: "hiddenAt",
+        label: "Hidden tasks position",
+        description:
+          '"bottom" hides tasks from the end of the list. ' +
+          '"top" hides tasks from the start (useful with status sort to collapse completed tasks).',
+        currentValue: cfg.hiddenAt ?? "bottom",
+        values: ["bottom", "top"],
+      },
+      {
         id: "autoClearCompleted",
         label: "Auto-clear completed tasks",
         description:
@@ -116,6 +125,10 @@ export async function openSettingsMenu(
         }
         if (id === "sortOrder") {
           cfg.sortOrder = newValue as TasksConfig["sortOrder"];
+          saveTasksConfig(cfg);
+        }
+        if (id === "hiddenAt") {
+          cfg.hiddenAt = newValue as "top" | "bottom";
           saveTasksConfig(cfg);
         }
       },

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -68,6 +68,15 @@ export async function openSettingsMenu(
         values: ["5", "10", "15", "20", "30", "50", "100"],
       },
       {
+        id: "sortOrder",
+        label: "Widget sort order",
+        description:
+          '"status" groups by completed → in-progress → pending. ' +
+          '"id" sorts by creation order.',
+        currentValue: cfg.sortOrder ?? "id",
+        values: ["id", "status"],
+      },
+      {
         id: "autoClearCompleted",
         label: "Auto-clear completed tasks",
         description:
@@ -103,6 +112,10 @@ export async function openSettingsMenu(
         }
         if (id === "maxVisible") {
           cfg.maxVisible = Number(newValue);
+          saveTasksConfig(cfg);
+        }
+        if (id === "sortOrder") {
+          cfg.sortOrder = newValue as "id" | "status";
           saveTasksConfig(cfg);
         }
       },

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -59,6 +59,15 @@ export async function openSettingsMenu(
         values: ["on", "off"],
       },
       {
+        id: "maxVisible",
+        label: "Max visible tasks in widget",
+        description:
+          "Only applies when 'Show all tasks' is OFF. " +
+          "Caps how many task lines the widget shows.",
+        currentValue: String(cfg.maxVisible ?? 10),
+        values: ["5", "10", "15", "20", "30", "50", "100"],
+      },
+      {
         id: "autoClearCompleted",
         label: "Auto-clear completed tasks",
         description:
@@ -90,6 +99,10 @@ export async function openSettingsMenu(
         }
         if (id === "showAll") {
           cfg.showAll = newValue === "on";
+          saveTasksConfig(cfg);
+        }
+        if (id === "maxVisible") {
+          cfg.maxVisible = Number(newValue);
           saveTasksConfig(cfg);
         }
       },

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -10,6 +10,7 @@
 
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { TaskStore } from "../task-store.js";
+import type { TasksConfig } from "../tasks-config.js";
 
 // ---- Types ----
 
@@ -73,7 +74,13 @@ export class TaskWidget {
   /** Whether the widget callback is currently registered. */
   private widgetRegistered = false;
 
+  private config: TasksConfig = {};
+
   constructor(private store: TaskStore) {}
+
+  setConfig(cfg: TasksConfig) {
+    this.config = cfg;
+  }
 
   setStore(store: TaskStore) {
     this.store = store;
@@ -137,7 +144,8 @@ export class TaskWidget {
     const spinnerChar = SPINNER[this.widgetFrame % SPINNER.length];
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
-    const visible = tasks.slice(0, MAX_VISIBLE_TASKS);
+    const showAll = this.config.showAll ?? false;
+    const visible = showAll ? tasks : tasks.slice(0, MAX_VISIBLE_TASKS);
     for (let i = 0; i < visible.length; i++) {
       const task = visible[i];
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";
@@ -193,8 +201,9 @@ export class TaskWidget {
       lines.push(truncate(text + suffix));
     }
 
-    if (tasks.length > MAX_VISIBLE_TASKS) {
-      lines.push(truncate(theme.fg("dim", `    … and ${tasks.length - MAX_VISIBLE_TASKS} more`)));
+    const hiddenCount = tasks.length - visible.length;
+    if (hiddenCount > 0) {
+      lines.push(truncate(theme.fg("dim", `    … and ${hiddenCount} more`)));
     }
 
     return lines;

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -142,7 +142,8 @@ export class TaskWidget {
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
     const showAll = this.config.showAll ?? false;
-    const visible = showAll ? tasks : tasks.slice(0, DEFAULT_MAX_VISIBLE_TASKS);
+    const limit = this.config.maxVisible ?? DEFAULT_MAX_VISIBLE_TASKS;
+    const visible = showAll ? tasks : tasks.slice(0, limit);
     for (let i = 0; i < visible.length; i++) {
       const task = visible[i];
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -32,7 +32,7 @@ export type UICtx = {
 /** Star spinner frames for animated active task indicator (matches Claude Code). */
 const SPINNER = ["✳", "✴", "✵", "✶", "✷", "✸", "✹", "✺", "✻", "✼", "✽"];
 
-const MAX_VISIBLE_TASKS = 10;
+const DEFAULT_MAX_VISIBLE_TASKS = 10;
 
 /** Per-task runtime metrics (elapsed time, token usage). */
 export interface TaskMetrics {
@@ -142,7 +142,7 @@ export class TaskWidget {
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
     const showAll = this.config.showAll ?? false;
-    const visible = showAll ? tasks : tasks.slice(0, MAX_VISIBLE_TASKS);
+    const visible = showAll ? tasks : tasks.slice(0, DEFAULT_MAX_VISIBLE_TASKS);
     for (let i = 0; i < visible.length; i++) {
       const task = visible[i];
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -141,9 +141,18 @@ export class TaskWidget {
     const spinnerChar = SPINNER[this.widgetFrame % SPINNER.length];
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
+    const sortOrder = this.config.sortOrder ?? "id";
+    let sorted = tasks; // already ID-ascending from store.list()
+    if (sortOrder === "status") {
+      const statusRank = (s: string) => s === "completed" ? 0 : s === "in_progress" ? 1 : 2;
+      sorted = [...tasks].sort((a, b) =>
+        statusRank(a.status) - statusRank(b.status) || Number(a.id) - Number(b.id)
+      );
+    }
+
     const showAll = this.config.showAll ?? false;
     const limit = this.config.maxVisible ?? DEFAULT_MAX_VISIBLE_TASKS;
-    const visible = showAll ? tasks : tasks.slice(0, limit);
+    const visible = showAll ? sorted : sorted.slice(0, limit);
     for (let i = 0; i < visible.length; i++) {
       const task = visible[i];
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -122,7 +122,8 @@ export class TaskWidget {
 
   /** Build widget lines from current live state. Called from the render callback. */
   private renderWidget(tui: any, theme: Theme): string[] {
-    const tasks = this.store.list();
+    const sortOrder = this.config.sortOrder ?? "id";
+    const tasks = this.store.list(sortOrder);
     const w = tui.terminal.columns;
     const truncate = (line: string) => truncateToWidth(line, w);
 
@@ -141,18 +142,9 @@ export class TaskWidget {
     const spinnerChar = SPINNER[this.widgetFrame % SPINNER.length];
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
-    const sortOrder = this.config.sortOrder ?? "id";
-    let sorted = tasks; // already ID-ascending from store.list()
-    if (sortOrder === "status") {
-      const statusRank = (s: string) => s === "completed" ? 0 : s === "in_progress" ? 1 : 2;
-      sorted = [...tasks].sort((a, b) =>
-        statusRank(a.status) - statusRank(b.status) || Number(a.id) - Number(b.id)
-      );
-    }
-
     const showAll = this.config.showAll ?? false;
     const limit = this.config.maxVisible ?? DEFAULT_MAX_VISIBLE_TASKS;
-    const visible = showAll ? sorted : sorted.slice(0, limit);
+    const visible = showAll ? tasks : tasks.slice(0, limit);
     for (let i = 0; i < visible.length; i++) {
       const task = visible[i];
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -12,6 +12,20 @@ import { truncateToWidth } from "@earendil-works/pi-tui";
 import type { TaskStore } from "../task-store.js";
 import type { TasksConfig } from "../tasks-config.js";
 
+// ---- Truncation ----
+
+import type { Task } from "../types.js";
+
+function truncateFromTop(tasks: Task[], limit: number): Task[] {
+  return tasks.slice(-limit);
+}
+
+function truncateFromBottom(tasks: Task[], limit: number): Task[] {
+  return tasks.slice(0, limit);
+}
+
+const TRUNCATE_FNS = { top: truncateFromTop, bottom: truncateFromBottom };
+
 // ---- Types ----
 
 export type Theme = {
@@ -144,7 +158,17 @@ export class TaskWidget {
 
     const showAll = this.config.showAll ?? false;
     const limit = this.config.maxVisible ?? DEFAULT_MAX_VISIBLE_TASKS;
-    const visible = showAll ? tasks : tasks.slice(0, limit);
+    const hiddenAt = this.config.hiddenAt ?? "bottom";
+    const visible = showAll ? tasks : TRUNCATE_FNS[hiddenAt](tasks, limit);
+
+    const hiddenCount = tasks.length - visible.length;
+    const overflowLine = hiddenCount > 0
+      ? truncate(theme.fg("dim", `    … and ${hiddenCount} more`))
+      : undefined;
+
+    if (overflowLine && hiddenAt === "top") {
+      lines.push(overflowLine);
+    }
     for (let i = 0; i < visible.length; i++) {
       const task = visible[i];
       const isActive = this.activeTaskIds.has(task.id) && task.status === "in_progress";
@@ -200,9 +224,8 @@ export class TaskWidget {
       lines.push(truncate(text + suffix));
     }
 
-    const hiddenCount = tasks.length - visible.length;
-    if (hiddenCount > 0) {
-      lines.push(truncate(theme.fg("dim", `    … and ${hiddenCount} more`)));
+    if (overflowLine && hiddenAt !== "top") {
+      lines.push(overflowLine);
     }
 
     return lines;

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -74,13 +74,10 @@ export class TaskWidget {
   /** Whether the widget callback is currently registered. */
   private widgetRegistered = false;
 
-  private config: TasksConfig = {};
-
-  constructor(private store: TaskStore) {}
-
-  setConfig(cfg: TasksConfig) {
-    this.config = cfg;
-  }
+  constructor(
+    private store: TaskStore,
+    private config: TasksConfig = {},
+  ) {}
 
   setStore(store: TaskStore) {
     this.store = store;

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskStore } from "../src/task-store.js";
 
 describe("TaskStore (in-memory)", () => {
@@ -59,6 +59,42 @@ describe("TaskStore (in-memory)", () => {
 
     const tasks = store.list("status");
     expect(tasks.map(t => t.subject)).toEqual(["Completed", "In progress", "Pending"]);
+  });
+
+  it("lists tasks sorted by most recently updated when sortOrder is 'recent'", () => {
+    vi.useFakeTimers({ now: 1000 });
+    store.create("First", "Desc");    // #1 created at 1000
+    vi.advanceTimersByTime(100);
+    store.create("Second", "Desc");   // #2 created at 1100
+    vi.advanceTimersByTime(100);
+    store.create("Third", "Desc");    // #3 created at 1200
+    vi.advanceTimersByTime(100);
+    store.update("1", { subject: "First updated" });  // #1 updated at 1300
+    vi.advanceTimersByTime(100);
+    store.update("3", { subject: "Third updated" });  // #3 updated at 1400
+
+    const tasks = store.list("recent");
+    // Most recently updated first: #3 (1400), #1 (1300), #2 (1100)
+    expect(tasks.map(t => t.id)).toEqual(["3", "1", "2"]);
+    vi.useRealTimers();
+  });
+
+  it("lists tasks sorted by least recently updated when sortOrder is 'oldest'", () => {
+    vi.useFakeTimers({ now: 1000 });
+    store.create("First", "Desc");    // #1 created at 1000
+    vi.advanceTimersByTime(100);
+    store.create("Second", "Desc");   // #2 created at 1100
+    vi.advanceTimersByTime(100);
+    store.create("Third", "Desc");    // #3 created at 1200
+    vi.advanceTimersByTime(100);
+    store.update("1", { subject: "First updated" });  // #1 updated at 1300
+    vi.advanceTimersByTime(100);
+    store.update("3", { subject: "Third updated" });  // #3 updated at 1400
+
+    const tasks = store.list("oldest");
+    // Least recently updated first: #2 (1100), #1 (1300), #3 (1400)
+    expect(tasks.map(t => t.id)).toEqual(["2", "1", "3"]);
+    vi.useRealTimers();
   });
 
   it("updates task status", () => {

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -50,6 +50,17 @@ describe("TaskStore (in-memory)", () => {
     expect(tasks.map(t => t.id)).toEqual(["1", "2", "3"]);
   });
 
+  it("lists tasks sorted by status when sortOrder is 'status'", () => {
+    store.create("Pending", "Desc");           // #1
+    store.create("Completed", "Desc");         // #2
+    store.create("In progress", "Desc");       // #3
+    store.update("2", { status: "completed" });
+    store.update("3", { status: "in_progress" });
+
+    const tasks = store.list("status");
+    expect(tasks.map(t => t.subject)).toEqual(["Completed", "In progress", "Pending"]);
+  });
+
   it("updates task status", () => {
     store.create("Test", "Desc");
     const { task, changedFields } = store.update("1", { status: "in_progress" });

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -172,7 +172,8 @@ describe("TaskWidget", () => {
   });
 
   it("shows all tasks when showAll is true", () => {
-    widget.setConfig({ showAll: true });
+    widget = new TaskWidget(store, { showAll: true });
+    widget.setUICtx(ui.ctx);
     for (let i = 0; i < 15; i++) {
       store.create(`Task ${i + 1}`, "Desc");
     }

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -213,6 +213,47 @@ describe("TaskWidget", () => {
     expect(lines[lines.length - 1]).not.toContain("more");
   });
 
+  it("truncates from top when hiddenAt is 'top'", () => {
+    widget = new TaskWidget(store, { sortOrder: "status", hiddenAt: "top", showAll: false, maxVisible: 5 });
+    widget.setUICtx(ui.ctx);
+    // 4 completed, 2 in_progress, 2 pending = 8 total, limit 5
+    for (let i = 1; i <= 4; i++) store.create(`Done ${i}`, "Desc");
+    for (let i = 1; i <= 2; i++) store.create(`Working ${i}`, "Desc");
+    for (let i = 1; i <= 2; i++) store.create(`Todo ${i}`, "Desc");
+    for (let i = 1; i <= 4; i++) store.update(String(i), { status: "completed" });
+    for (let i = 5; i <= 6; i++) store.update(String(i), { status: "in_progress" });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // header + overflow line + 5 visible = 7 lines
+    expect(lines).toHaveLength(7);
+    // overflow at top (after header)
+    expect(lines[1]).toContain("3 more");
+    // all in_progress and pending visible
+    expect(lines.some(l => l.includes("Working 1"))).toBe(true);
+    expect(lines.some(l => l.includes("Todo 2"))).toBe(true);
+    // only newest completed (#4) visible
+    expect(lines.some(l => l.includes("Done 4"))).toBe(true);
+    // oldest completed hidden
+    expect(lines.some(l => l.includes("Done 1"))).toBe(false);
+    expect(lines.some(l => l.includes("Done 3"))).toBe(false);
+  });
+
+  it("truncates from bottom by default", () => {
+    widget = new TaskWidget(store, { maxVisible: 3 });
+    widget.setUICtx(ui.ctx);
+    for (let i = 1; i <= 5; i++) store.create(`Task ${i}`, "Desc");
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // header + 3 tasks + overflow at bottom = 5 lines
+    expect(lines).toHaveLength(5);
+    expect(lines[1]).toContain("Task 1");
+    expect(lines[3]).toContain("Task 3");
+    expect(lines[4]).toContain("2 more");
+    expect(lines.some(l => l.includes("Task 4"))).toBe(false);
+  });
+
   it("sorts tasks by status when sortOrder is 'status'", () => {
     widget = new TaskWidget(store, { sortOrder: "status" });
     widget.setUICtx(ui.ctx);

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -171,6 +171,19 @@ describe("TaskWidget", () => {
     expect(lines[11]).toContain("5 more");
   });
 
+  it("shows all tasks when showAll is true", () => {
+    widget.setConfig({ showAll: true });
+    for (let i = 0; i < 15; i++) {
+      store.create(`Task ${i + 1}`, "Desc");
+    }
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // header + 15 tasks, no overflow line
+    expect(lines).toHaveLength(16);
+    expect(lines[lines.length - 1]).not.toContain("more");
+  });
+
   it("tracks token usage for active tasks", () => {
     store.create("Active task", "Desc", "Running");
     store.update("1", { status: "in_progress" });

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -171,8 +171,36 @@ describe("TaskWidget", () => {
     expect(lines[11]).toContain("5 more");
   });
 
-  it("shows all tasks when showAll is true", () => {
-    widget = new TaskWidget(store, { showAll: true });
+  it("respects maxVisible config", () => {
+    widget = new TaskWidget(store, { maxVisible: 5 });
+    widget.setUICtx(ui.ctx);
+    for (let i = 0; i < 15; i++) {
+      store.create(`Task ${i + 1}`, "Desc");
+    }
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // header + 5 tasks + "… and 10 more"
+    expect(lines).toHaveLength(7);
+    expect(lines[6]).toContain("10 more");
+  });
+
+  it("shows all tasks when limit exceeds task count", () => {
+    widget = new TaskWidget(store, { maxVisible: 10 });
+    widget.setUICtx(ui.ctx);
+    for (let i = 0; i < 3; i++) {
+      store.create(`Task ${i + 1}`, "Desc");
+    }
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // header + 3 tasks, no overflow
+    expect(lines).toHaveLength(4);
+    expect(lines[lines.length - 1]).not.toContain("more");
+  });
+
+  it("shows all tasks when showAll is true even with maxVisible set", () => {
+    widget = new TaskWidget(store, { showAll: true, maxVisible: 5 });
     widget.setUICtx(ui.ctx);
     for (let i = 0; i < 15; i++) {
       store.create(`Task ${i + 1}`, "Desc");

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -213,6 +213,54 @@ describe("TaskWidget", () => {
     expect(lines[lines.length - 1]).not.toContain("more");
   });
 
+  it("sorts tasks by status when sortOrder is 'status'", () => {
+    widget = new TaskWidget(store, { sortOrder: "status" });
+    widget.setUICtx(ui.ctx);
+    store.create("Pending task", "Desc");           // #1
+    store.create("Completed task", "Desc");         // #2
+    store.create("In progress task", "Desc");       // #3
+    store.update("2", { status: "completed" });
+    store.update("3", { status: "in_progress" });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // header + 3 tasks: completed, in_progress, pending
+    expect(lines[1]).toContain("Completed task");
+    expect(lines[2]).toContain("In progress task");
+    expect(lines[3]).toContain("Pending task");
+  });
+
+  it("defaults to ID order when sortOrder is unset", () => {
+    store.create("Pending task", "Desc");           // #1
+    store.create("Completed task", "Desc");         // #2
+    store.create("In progress task", "Desc");       // #3
+    store.update("2", { status: "completed" });
+    store.update("3", { status: "in_progress" });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    expect(lines[1]).toContain("Pending task");
+    expect(lines[2]).toContain("Completed task");
+    expect(lines[3]).toContain("In progress task");
+  });
+
+  it("keeps ID order when sortOrder is 'id'", () => {
+    widget = new TaskWidget(store, { sortOrder: "id" });
+    widget.setUICtx(ui.ctx);
+    store.create("Pending task", "Desc");           // #1
+    store.create("Completed task", "Desc");         // #2
+    store.create("In progress task", "Desc");       // #3
+    store.update("2", { status: "completed" });
+    store.update("3", { status: "in_progress" });
+    widget.update();
+
+    const lines = renderWidget(ui.state);
+    // ID order: #1 pending, #2 completed, #3 in_progress
+    expect(lines[1]).toContain("Pending task");
+    expect(lines[2]).toContain("Completed task");
+    expect(lines[3]).toContain("In progress task");
+  });
+
   it("tracks token usage for active tasks", () => {
     store.create("Active task", "Desc", "Running");
     store.update("1", { status: "in_progress" });


### PR DESCRIPTION
## Summary

The widget hardcodes a 10-task cap and always sorts by ID, which hides newer tasks and offers no way to customize the display. This PR adds five new settings to control how tasks are shown in the widget, all accessible from the `/tasks` → Settings menu.

This is based on top of #21 .

## New Settings

### `showAll` (default: `false`)
When `true`, every task is shown regardless of the visible limit.

```json
{ "showAll": true }
```
<img width="1746" height="854" alt="CleanShot 2026-05-13 at 16 21 27@2x" src="https://github.com/user-attachments/assets/ae2df4e1-47e4-4eef-82d6-3b50e29ccc21" />


### `maxVisible` (default: `10`)
Caps how many task lines the widget shows. Only applies when `showAll` is `false`. Configurable via menu: 5, 10, 15, 20, 30, 50, 100.

```json
{ "showAll": false, "maxVisible": 20 }
```
<img width="1704" height="696" alt="CleanShot 2026-05-13 at 16 21 51@2x" src="https://github.com/user-attachments/assets/174cdd10-89ca-40f9-88ab-d58b147f88e6" />

### `sortOrder` (default: `"id"`)
Controls task sort order in the widget:
- `"id"` — creation order (existing behaviour)
- `"status"` — groups by completed → in-progress → pending
- `"recent"` — most recently updated first
- `"oldest"` — least recently updated first

```json
{ "sortOrder": "status" }
```
<img width="1730" height="836" alt="CleanShot 2026-05-13 at 16 22 07@2x" src="https://github.com/user-attachments/assets/9b466ac9-005b-4749-8a62-4eea44ecb7b3" />
<img width="1760" height="848" alt="CleanShot 2026-05-13 at 16 22 15@2x" src="https://github.com/user-attachments/assets/b9d727e4-2919-4ab8-bbae-8f951eb1f2cd" />
<img width="1770" height="830" alt="CleanShot 2026-05-13 at 16 22 22@2x" src="https://github.com/user-attachments/assets/17ded0c0-3258-4681-b436-75cb536b169c" />
<img width="1716" height="828" alt="CleanShot 2026-05-13 at 16 22 30@2x" src="https://github.com/user-attachments/assets/496de078-3224-4566-9d0f-421f0ff204bb" />


### `hiddenAt` (default: `"bottom"`)
When tasks exceed `maxVisible`, controls where hidden tasks collapse:
- `"bottom"` — hides from the end of the list (existing behaviour)
- `"top"` — hides from the start (useful with `"status"` sort to collapse completed tasks while keeping active work visible)

```json
{ "sortOrder": "status", "hiddenAt": "top", "maxVisible": 10 }
```
<img width="1704" height="696" alt="CleanShot 2026-05-13 at 16 21 51@2x" src="https://github.com/user-attachments/assets/174cdd10-89ca-40f9-88ab-d58b147f88e6" />

### Combined example

Show up to 15 tasks, sorted by status, with completed tasks collapsing at the top:

```json
{
  "sortOrder": "status",
  "hiddenAt": "top",
  "maxVisible": 15
}
```

## Details

- Sort logic lives in `TaskStore.list(sortOrder)` with extracted comparator functions, keeping the widget thin
- All settings are persisted in `.pi/tasks-config.json` alongside existing settings
- Config is injected into the widget via constructor (mutable reference, no setter needed)
- All defaults preserve existing behaviour — no breaking changes
- All checks pass locally (lint, typecheck, 159 tests)