### PR TITLE
feat: add batch task creation to TaskCreate tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://github.com/user-attachments/assets/1d0ee87a-e0a5-4bfa-a9b9-2f9144cb905b
 
 ## Features
 
-- **7 LLM-callable tools** — `TaskCreate`, `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, `TaskExecute` — matching Claude Code's exact tool specs and descriptions
+- **7 LLM-callable tools** — `TaskCreate` (single + batch), `TaskList`, `TaskGet`, `TaskUpdate`, `TaskOutput`, `TaskStop`, `TaskExecute`
 - **Persistent widget** — live task list above the editor with `✔`/`◼`/`◻` status icons, task numbers (`#1`, `#2`, …), strikethrough for completed tasks, star spinner (`✳✽`) for active tasks with elapsed time and token counts
 - **System-reminder injection** — periodic `<system-reminder>` nudges injected into the upcoming LLM request (via the `context` hook, transient and never persisted) when task tools haven't been used recently, or when a task is left stuck `in_progress` after a text-only turn. Shaped after Claude Code's todo reminders — an empty-list nudge or a JSON echo of the current list (capped at 10 tasks)
 - **Prompt guidelines** — workflow contract encoded in tool descriptions, nudging the LLM at the point of tool use
@@ -90,18 +90,53 @@ See [Writing your own sort order](CUSTOMIZING.md#writing-your-own-sort-order) fo
 
 ### `TaskCreate`
 
-Create a structured task. Used proactively for complex multi-step work.
+Create one or more structured tasks. Pass `subject` and `description` for a single task, or a `tasks` array for batch creation.
+
+**Single task** (backward compatible):
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `subject` | string | yes | Brief imperative title |
-| `description` | string | yes | Detailed context and acceptance criteria |
+| `subject` | string | yes* | Brief imperative title |
+| `description` | string | yes* | Detailed context and acceptance criteria |
 | `activeForm` | string | no | Present continuous form for spinner (e.g., "Running tests") |
 | `agentType` | string | no | Agent type for subagent execution (e.g., `"general-purpose"`, `"Explore"`) |
 | `metadata` | object | no | Arbitrary key-value pairs |
 
+*\*Required when not using `tasks`.*
+
+**Batch creation** (via `tasks` array):
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tasks` | array | yes* | Array of task objects (min 1 item). Mutually exclusive with `subject`/`description`. |
+| `tasks[].subject` | string | yes | Brief imperative title |
+| `tasks[].description` | string | yes | Detailed context and acceptance criteria |
+| `tasks[].activeForm` | string | no | Present continuous form for spinner |
+| `tasks[].agentType` | string | no | Agent type for subagent execution via TaskExecute |
+| `tasks[].metadata` | object | no | Arbitrary key-value pairs |
+
+*\*Required when not using `subject`/`description`. You cannot mix `tasks` with `subject`/`description`.*
+
 ```
 → Task #1 created successfully: Fix authentication bug
+```
+
+Batch example:
+```json
+{
+  "tasks": [
+    { "subject": "Design the API", "description": "Decide the shape" },
+    { "subject": "Implement the handler", "description": "Write the code" },
+    { "subject": "Write tests", "description": "Cover edge cases" }
+  ]
+}
+```
+
+```
+→ Created 3 tasks:
+  #1 Design the API
+  #2 Implement the handler
+  #3 Write tests
 ```
 
 ### `TaskList`
@@ -357,7 +392,7 @@ If [`pi-subagents`](https://github.com/tintinweb/pi-subagents) is not installed,
 src/
 ├── index.ts            # Extension entry: 7 tools + /tasks command + widget + subagent integration
 ├── types.ts            # Task, TaskStatus, BackgroundProcess types
-├── task-store.ts       # File-backed store with CRUD, dependencies, locking
+├── task-store.ts       # File-backed store with CRUD, batch creation, dependencies, locking
 ├── auto-clear.ts       # Turn-based auto-clearing of completed tasks (AutoClearManager)
 ├── tasks-config.ts     # Global defaults and project override persistence
 ├── process-tracker.ts  # Background process output buffering and stop

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See [Writing your own sort order](CUSTOMIZING.md#writing-your-own-sort-order) fo
 
 ### `TaskCreate`
 
-Create one or more structured tasks. Pass `subject` and `description` for a single task, or a `tasks` array for batch creation.
+Create one or more structured tasks. Pass `subject` and `description` for a single task, or a `batch` array for batch creation.
 
 **Single task** (backward compatible):
 
@@ -102,20 +102,20 @@ Create one or more structured tasks. Pass `subject` and `description` for a sing
 | `agentType` | string | no | Agent type for subagent execution (e.g., `"general-purpose"`, `"Explore"`) |
 | `metadata` | object | no | Arbitrary key-value pairs |
 
-*\*Required when not using `tasks`.*
+*\*Required when not using `batch`.*
 
-**Batch creation** (via `tasks` array):
+**Batch creation** (via `batch` array):
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `tasks` | array | yes* | Array of task objects (min 1 item). Mutually exclusive with `subject`/`description`. |
-| `tasks[].subject` | string | yes | Brief imperative title |
-| `tasks[].description` | string | yes | Detailed context and acceptance criteria |
-| `tasks[].activeForm` | string | no | Present continuous form for spinner |
-| `tasks[].agentType` | string | no | Agent type for subagent execution via TaskExecute |
-| `tasks[].metadata` | object | no | Arbitrary key-value pairs |
+| `batch` | array | yes* | Array of task items (min 1 item). Mutually exclusive with `subject`/`description`. |
+| `batch[].subject` | string | yes | Brief imperative title |
+| `batch[].description` | string | yes | Detailed context and acceptance criteria |
+| `batch[].activeForm` | string | no | Present continuous form for spinner |
+| `batch[].agentType` | string | no | Agent type for subagent execution via TaskExecute |
+| `batch[].metadata` | object | no | Arbitrary key-value pairs |
 
-*\*Required when not using `subject`/`description`. You cannot mix `tasks` with `subject`/`description`.*
+*\*Required when not using `subject`/`description`. You cannot mix `batch` with `subject`/`description`.*
 
 ```
 → Task #1 created successfully: Fix authentication bug
@@ -124,7 +124,7 @@ Create one or more structured tasks. Pass `subject` and `description` for a sing
 Batch example:
 ```json
 {
-  "tasks": [
+  "batch": [
     { "subject": "Design the API", "description": "Decide the shape" },
     { "subject": "Implement the handler", "description": "Write the code" },
     { "subject": "Write tests", "description": "Cover edge cases" }

--- a/src/index.ts
+++ b/src/index.ts
@@ -620,12 +620,6 @@ Skip using this tool when:
 
 NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
 
-## Creating Single vs Multiple Tasks
-
-- **Single task**: Provide \`subject\` and \`description\` (plus optional \`activeForm\`, \`agentType\`, \`metadata\`).
-- **Multiple tasks**: Provide a \`tasks\` array instead. Each item has its own \`subject\`, \`description\`, and optional \`activeForm\`, \`agentType\`, \`metadata\`.
-- Using \`tasks\` is more efficient than calling \`TaskCreate\` repeatedly — it creates all tasks in a single atomic operation.
-- You cannot mix \`subject\`/\`description\` with \`tasks\` — use one or the other.
 
 ## Task Fields
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * @tintinweb/pi-tasks — A pi extension providing Claude Code-style task tracking and coordination.
  *
  * Tools:
- *   TaskCreate   — Create a structured task
+ *   TaskCreate   — Create one or more structured tasks (single or batch)
  *   TaskList     — List all tasks with status
  *   TaskGet      — Get full task details
  *   TaskUpdate   — Update task fields, status, dependencies
@@ -620,6 +620,13 @@ Skip using this tool when:
 
 NOTE that you should not use this tool if there is only one trivial task to do. In this case you are better off just doing the task directly.
 
+## Creating Single vs Multiple Tasks
+
+- **Single task**: Provide \`subject\` and \`description\` (plus optional \`activeForm\`, \`agentType\`, \`metadata\`).
+- **Multiple tasks**: Provide a \`tasks\` array instead. Each item has its own \`subject\`, \`description\`, and optional \`activeForm\`, \`agentType\`, \`metadata\`.
+- Using \`tasks\` is more efficient than calling \`TaskCreate\` repeatedly — it creates all tasks in a single atomic operation.
+- You cannot mix \`subject\`/\`description\` with \`tasks\` — use one or the other.
+
 ## Task Fields
 
 - **subject**: A brief, actionable title in imperative form (e.g., "Fix authentication bug in login flow")
@@ -636,16 +643,29 @@ All tasks are created with status \`pending\`.
 - Check TaskList first to avoid creating duplicate tasks
 - Include \`agentType\` (e.g., "general-purpose", "Explore") to mark tasks for subagent execution via TaskExecute`,
     promptGuidelines: [
-      "When working on complex multi-step tasks, use TaskCreate to track progress and TaskUpdate to update status.",
+      "When working with complex multi-step tasks, use TaskCreate to track progress and TaskUpdate to update status.",
       "Mark tasks as in_progress before starting work and completed when done.",
       "Use TaskList to check for available work after completing a task.",
+      "Prefer using the `tasks` array to batch-create multiple tasks at once instead of calling TaskCreate repeatedly.",
     ],
     parameters: Type.Object({
-      subject: Type.String({ description: "A brief title for the task" }),
-      description: Type.String({ description: "A detailed description of what needs to be done" }),
+      // Single-task parameters (backward compatible)
+      subject: Type.Optional(Type.String({ description: "A brief title for the task. Use this for a single task, or use `tasks` for multiple." })),
+      description: Type.Optional(Type.String({ description: "A detailed description of what needs to be done. Use this for a single task, or use `tasks` for multiple." })),
       activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in spinner when in_progress (e.g., 'Running tests')" })),
       agentType: Type.Optional(Type.String({ description: "Agent type for subagent execution (e.g., 'general-purpose', 'Explore'). Tasks with agentType can be started via TaskExecute." })),
       metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Arbitrary metadata to attach to the task" })),
+      // Batch parameter
+      tasks: Type.Optional(Type.Array(
+        Type.Object({
+          subject: Type.String({ description: "A brief title for the task" }),
+          description: Type.String({ description: "A detailed description of what needs to be done" }),
+          activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in spinner when in_progress" })),
+          agentType: Type.Optional(Type.String({ description: "Agent type for subagent execution via TaskExecute" })),
+          metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Arbitrary metadata to attach to the task" })),
+        }),
+        { description: "Array of tasks to create in batch. Use this instead of subject/description for creating multiple tasks at once.", minItems: 1 },
+      )),
     }),
 
     execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
@@ -653,7 +673,40 @@ All tasks are created with status \`pending\`.
       // cannot be relied on for that: they only tick at `turn_start`, so a run that ends
       // right after its last completion freezes one mid-count.
       autoClear.startNewBatch();
-      const meta = params.metadata ?? {};
+
+      const hasTasks = params.tasks && params.tasks.length > 0;
+      const hasScalar = params.subject !== undefined || params.description !== undefined;
+
+      if (hasTasks && hasScalar) {
+        return Promise.resolve(textResult("Error: Cannot use `tasks` array and `subject`/`description` together. Use one or the other."));
+      }
+
+      if (hasTasks) {
+        // Batch creation
+        const items = params.tasks!.map(t => {
+          const meta = t.metadata ? { ...t.metadata } : {};
+          if (t.agentType) meta.agentType = t.agentType;
+          return {
+            subject: t.subject,
+            description: t.description,
+            activeForm: t.activeForm,
+            metadata: Object.keys(meta).length > 0 ? meta : undefined,
+          } as { subject: string; description: string; activeForm?: string; metadata?: Record<string, any> };
+        });
+        const created = store.createMany(items);
+        widget.update();
+        const lines = [`Created ${created.length} task${created.length === 1 ? "" : "s"}:`];
+        for (const task of created) {
+          lines.push(`  #${task.id} ${task.subject}`);
+        }
+        return Promise.resolve(textResult(lines.join("\n")));
+      }
+
+      // Single-task creation (backward compatible)
+      if (!params.subject || !params.description) {
+        return Promise.resolve(textResult("Error: `subject` and `description` are required when not using `tasks`. Provide both, or use `tasks` for batch creation."));
+      }
+      const meta = params.metadata ? { ...params.metadata } : {};
       if (params.agentType) meta.agentType = params.agentType;
       const task = store.create(params.subject, params.description, params.activeForm, Object.keys(meta).length > 0 ? meta : undefined);
       widget.update();

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,17 +640,17 @@ All tasks are created with status \`pending\`.
       "When working with complex multi-step tasks, use TaskCreate to track progress and TaskUpdate to update status.",
       "Mark tasks as in_progress before starting work and completed when done.",
       "Use TaskList to check for available work after completing a task.",
-      "Prefer using the `tasks` array to batch-create multiple tasks at once instead of calling TaskCreate repeatedly.",
+      "Prefer using the `batch` array to create multiple tasks at once instead of calling TaskCreate repeatedly.",
     ],
     parameters: Type.Object({
       // Single-task parameters (backward compatible)
-      subject: Type.Optional(Type.String({ description: "A brief title for the task. Use this for a single task, or use `tasks` for multiple." })),
-      description: Type.Optional(Type.String({ description: "A detailed description of what needs to be done. Use this for a single task, or use `tasks` for multiple." })),
+      subject: Type.Optional(Type.String({ description: "A brief title for the task. Use this for a single task, or use `batch` for multiple." })),
+      description: Type.Optional(Type.String({ description: "A detailed description of what needs to be done. Use this for a single task, or use `batch` for multiple." })),
       activeForm: Type.Optional(Type.String({ description: "Present continuous form shown in spinner when in_progress (e.g., 'Running tests')" })),
       agentType: Type.Optional(Type.String({ description: "Agent type for subagent execution (e.g., 'general-purpose', 'Explore'). Tasks with agentType can be started via TaskExecute." })),
       metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Arbitrary metadata to attach to the task" })),
-      // Batch parameter
-      tasks: Type.Optional(Type.Array(
+      // Batch parameter — pass an array to create multiple tasks in one call
+      batch: Type.Optional(Type.Array(
         Type.Object({
           subject: Type.String({ description: "A brief title for the task" }),
           description: Type.String({ description: "A detailed description of what needs to be done" }),
@@ -658,7 +658,7 @@ All tasks are created with status \`pending\`.
           agentType: Type.Optional(Type.String({ description: "Agent type for subagent execution via TaskExecute" })),
           metadata: Type.Optional(Type.Record(Type.String(), Type.Any(), { description: "Arbitrary metadata to attach to the task" })),
         }),
-        { description: "Array of tasks to create in batch. Use this instead of subject/description for creating multiple tasks at once.", minItems: 1 },
+        { description: "Array of task items to create in one call. Mutually exclusive with subject/description.", minItems: 1 },
       )),
     }),
 
@@ -668,16 +668,16 @@ All tasks are created with status \`pending\`.
       // right after its last completion freezes one mid-count.
       autoClear.startNewBatch();
 
-      const hasTasks = params.tasks && params.tasks.length > 0;
+      const hasBatch = params.batch && params.batch.length > 0;
       const hasScalar = params.subject !== undefined || params.description !== undefined;
 
-      if (hasTasks && hasScalar) {
-        return Promise.resolve(textResult("Error: Cannot use `tasks` array and `subject`/`description` together. Use one or the other."));
+      if (hasBatch && hasScalar) {
+        return Promise.resolve(textResult("Error: Cannot use `batch` array and `subject`/`description` together. Use one or the other."));
       }
 
-      if (hasTasks) {
+      if (hasBatch) {
         // Batch creation
-        const items = params.tasks!.map(t => {
+        const items = params.batch!.map(t => {
           const meta = t.metadata ? { ...t.metadata } : {};
           if (t.agentType) meta.agentType = t.agentType;
           return {
@@ -698,7 +698,7 @@ All tasks are created with status \`pending\`.
 
       // Single-task creation (backward compatible)
       if (!params.subject || !params.description) {
-        return Promise.resolve(textResult("Error: `subject` and `description` are required when not using `tasks`. Provide both, or use `tasks` for batch creation."));
+        return Promise.resolve(textResult("Error: `subject` and `description` are required when not using `batch`. Provide both, or use `batch` for batch creation."));
       }
       const meta = params.metadata ? { ...params.metadata } : {};
       if (params.agentType) meta.agentType = params.agentType;

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -197,6 +197,32 @@ export class TaskStore {
     });
   }
 
+  /** Create multiple tasks in a single atomic lock. Assigns sequential IDs. */
+  createMany(items: Array<{ subject: string; description: string; activeForm?: string; metadata?: Record<string, any> }>): Task[] {
+    return this.withLock(() => {
+      const now = Date.now();
+      const created: Task[] = [];
+      for (const item of items) {
+        const task: Task = {
+          id: String(this.nextId++),
+          subject: item.subject,
+          description: item.description,
+          status: "pending",
+          activeForm: item.activeForm,
+          owner: undefined,
+          metadata: item.metadata ?? {},
+          blocks: [],
+          blockedBy: [],
+          createdAt: now,
+          updatedAt: now,
+        };
+        this.tasks.set(task.id, task);
+        created.push(task);
+      }
+      return created;
+    });
+  }
+
   get(id: string): Task | undefined {
     if (this.filePath) this.load();
     return this.tasks.get(id);

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -1159,3 +1159,148 @@ describe("Cascade data injection (buildTaskPrompt)", () => {
     expect(bPrompt).not.toContain("Prerequisite task results");
   });
 });
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TaskCreate batch tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("TaskCreate batch mode", () => {
+  let mock: ReturnType<typeof mockPi>;
+
+  beforeEach(() => {
+    mock = mockPi();
+    initExtension(mock.pi as any);
+  });
+
+  it("creates multiple tasks via tasks array", async () => {
+    const result = await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "Step one", description: "Do the first thing" },
+        { subject: "Step two", description: "Do the second thing" },
+        { subject: "Step three", description: "Do the third thing" },
+      ],
+    });
+
+    const text = result.content[0].text as string;
+    expect(text).toContain("Created 3 tasks");
+    expect(text).toContain("#1 Step one");
+    expect(text).toContain("#2 Step two");
+    expect(text).toContain("#3 Step three");
+  });
+
+  it("created batch tasks appear in TaskList", async () => {
+    await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "Alpha", description: "A" },
+        { subject: "Beta", description: "B" },
+      ],
+    });
+
+    const list = await mock.executeTool("TaskList", {});
+    const text = list.content[0].text as string;
+    expect(text).toContain("Alpha");
+    expect(text).toContain("Beta");
+  });
+
+  it("supports agentType stored in metadata for batch tasks", async () => {
+    await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "Agent task", description: "Run me", agentType: "general-purpose" },
+      ],
+    });
+
+    const details = await mock.executeTool("TaskGet", { taskId: "1" });
+    expect(details.content[0].text).toContain("general-purpose");
+  });
+
+  it("batch IDs are sequential after prior TaskCreate calls", async () => {
+    await mock.executeTool("TaskCreate", {
+      subject: "Existing",
+      description: "Already here",
+    });
+
+    const result = await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "Bulk A", description: "D" },
+        { subject: "Bulk B", description: "D" },
+      ],
+    });
+
+    const text = result.content[0].text as string;
+    expect(text).toContain("#2 Bulk A");
+    expect(text).toContain("#3 Bulk B");
+  });
+
+  it("returns singular wording for a single task in array", async () => {
+    const result = await mock.executeTool("TaskCreate", {
+      tasks: [{ subject: "Just one", description: "Lonely task" }],
+    });
+
+    expect(result.content[0].text).toContain("Created 1 task:");
+  });
+
+  it("rejects mixing tasks array with subject/description", async () => {
+    const result = await mock.executeTool("TaskCreate", {
+      tasks: [{ subject: "A", description: "D" }],
+      subject: "Conflicting",
+      description: "Should not work",
+    });
+
+    expect(result.content[0].text).toContain("Error");
+    expect(result.content[0].text).toContain("Cannot use");
+  });
+
+  it("requires subject and description when not using tasks array", async () => {
+    const result = await mock.executeTool("TaskCreate", {
+      subject: "Missing description",
+    });
+
+    expect(result.content[0].text).toContain("Error");
+    expect(result.content[0].text).toContain("required");
+  });
+
+  it("backward-compatible single task creation still works", async () => {
+    const result = await mock.executeTool("TaskCreate", {
+      subject: "Fix auth bug",
+      description: "Fix the login flow",
+      activeForm: "Fixing auth bug",
+    });
+
+    expect(result.content[0].text).toContain("Task #1 created successfully: Fix auth bug");
+  });
+
+  it("preserves activeForm and metadata in batch tasks", async () => {
+    await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "A", description: "D", activeForm: "Doing A", metadata: { priority: "high" } },
+        { subject: "B", description: "D" },
+      ],
+    });
+
+    const taskA = await mock.executeTool("TaskGet", { taskId: "1" });
+    expect(taskA.content[0].text).toContain("priority");
+    expect(taskA.content[0].text).toContain("high");
+
+    const taskB = await mock.executeTool("TaskGet", { taskId: "2" });
+    const taskBText = taskB.content[0].text as string;
+    expect(taskBText).toContain("B");
+    // Task B should not have priority metadata
+    expect(taskBText).not.toContain("priority");
+  });
+
+  it("batch creation is atomic — all tasks appear after call", async () => {
+    await mock.executeTool("TaskCreate", {
+      tasks: [
+        { subject: "One", description: "1" },
+        { subject: "Two", description: "2" },
+        { subject: "Three", description: "3" },
+      ],
+    });
+
+    const list = await mock.executeTool("TaskList", {});
+    const text = list.content[0].text as string;
+    expect(text).toContain("One");
+    expect(text).toContain("Two");
+    expect(text).toContain("Three");
+  });
+});

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -1174,7 +1174,7 @@ describe("TaskCreate batch mode", () => {
 
   it("creates multiple tasks via tasks array", async () => {
     const result = await mock.executeTool("TaskCreate", {
-      tasks: [
+      batch: [
         { subject: "Step one", description: "Do the first thing" },
         { subject: "Step two", description: "Do the second thing" },
         { subject: "Step three", description: "Do the third thing" },
@@ -1190,7 +1190,7 @@ describe("TaskCreate batch mode", () => {
 
   it("created batch tasks appear in TaskList", async () => {
     await mock.executeTool("TaskCreate", {
-      tasks: [
+      batch: [
         { subject: "Alpha", description: "A" },
         { subject: "Beta", description: "B" },
       ],
@@ -1204,7 +1204,7 @@ describe("TaskCreate batch mode", () => {
 
   it("supports agentType stored in metadata for batch tasks", async () => {
     await mock.executeTool("TaskCreate", {
-      tasks: [
+      batch: [
         { subject: "Agent task", description: "Run me", agentType: "general-purpose" },
       ],
     });
@@ -1220,7 +1220,7 @@ describe("TaskCreate batch mode", () => {
     });
 
     const result = await mock.executeTool("TaskCreate", {
-      tasks: [
+      batch: [
         { subject: "Bulk A", description: "D" },
         { subject: "Bulk B", description: "D" },
       ],
@@ -1233,7 +1233,7 @@ describe("TaskCreate batch mode", () => {
 
   it("returns singular wording for a single task in array", async () => {
     const result = await mock.executeTool("TaskCreate", {
-      tasks: [{ subject: "Just one", description: "Lonely task" }],
+      batch: [{ subject: "Just one", description: "Lonely task" }],
     });
 
     expect(result.content[0].text).toContain("Created 1 task:");
@@ -1241,7 +1241,7 @@ describe("TaskCreate batch mode", () => {
 
   it("rejects mixing tasks array with subject/description", async () => {
     const result = await mock.executeTool("TaskCreate", {
-      tasks: [{ subject: "A", description: "D" }],
+      batch: [{ subject: "A", description: "D" }],
       subject: "Conflicting",
       description: "Should not work",
     });
@@ -1271,7 +1271,7 @@ describe("TaskCreate batch mode", () => {
 
   it("preserves activeForm and metadata in batch tasks", async () => {
     await mock.executeTool("TaskCreate", {
-      tasks: [
+      batch: [
         { subject: "A", description: "D", activeForm: "Doing A", metadata: { priority: "high" } },
         { subject: "B", description: "D" },
       ],
@@ -1290,7 +1290,7 @@ describe("TaskCreate batch mode", () => {
 
   it("batch creation is atomic — all tasks appear after call", async () => {
     await mock.executeTool("TaskCreate", {
-      tasks: [
+      batch: [
         { subject: "One", description: "1" },
         { subject: "Two", description: "2" },
         { subject: "Three", description: "3" },

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -628,3 +628,82 @@ describe("TaskStore (malformed files)", () => {
     expect(new TaskStore(file).create("Next", "d").id).toBe("42");
   });
 });
+
+describe("TaskStore createMany", () => {
+  let store: TaskStore;
+
+  beforeEach(() => {
+    store = new TaskStore();
+  });
+
+  it("creates multiple tasks with sequential IDs", () => {
+    const created = store.createMany([
+      { subject: "Task A", description: "Desc A" },
+      { subject: "Task B", description: "Desc B" },
+      { subject: "Task C", description: "Desc C" },
+    ]);
+
+    expect(created).toHaveLength(3);
+    expect(created.map(t => t.id)).toEqual(["1", "2", "3"]);
+    expect(created.map(t => t.subject)).toEqual(["Task A", "Task B", "Task C"]);
+    expect(store.list()).toHaveLength(3);
+  });
+
+  it("sets status to pending for all created tasks", () => {
+    const created = store.createMany([
+      { subject: "A", description: "D" },
+      { subject: "B", description: "D" },
+    ]);
+    expect(created.every(t => t.status === "pending")).toBe(true);
+  });
+
+  it("preserves activeForm and metadata per task", () => {
+    const created = store.createMany([
+      { subject: "A", description: "D", activeForm: "Doing A", metadata: { key: "val" } },
+      { subject: "B", description: "D" },
+    ]);
+    expect(created[0].activeForm).toBe("Doing A");
+    expect(created[0].metadata).toEqual({ key: "val" });
+    expect(created[1].activeForm).toBeUndefined();
+    expect(created[1].metadata).toEqual({});
+  });
+
+  it("continues ID counter from existing tasks", () => {
+    store.create("Existing", "Desc");
+    const created = store.createMany([
+      { subject: "Bulk A", description: "D" },
+      { subject: "Bulk B", description: "D" },
+    ]);
+    expect(created.map(t => t.id)).toEqual(["2", "3"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    const created = store.createMany([]);
+    expect(created).toEqual([]);
+    expect(store.list()).toHaveLength(0);
+  });
+
+  it("persists bulk-created tasks in file-backed mode", () => {
+    const testId = `test-bulk-${Date.now()}`;
+    const tasksDir = join(homedir(), ".pi", "tasks");
+    const filePath = join(tasksDir, `${testId}.json`);
+
+    try {
+      const store1 = new TaskStore(testId);
+      store1.createMany([
+        { subject: "Persisted A", description: "D" },
+        { subject: "Persisted B", description: "D" },
+      ]);
+
+      const store2 = new TaskStore(testId);
+      const tasks = store2.list();
+      expect(tasks).toHaveLength(2);
+      expect(tasks[0].subject).toBe("Persisted A");
+      expect(tasks[1].subject).toBe("Persisted B");
+    } finally {
+      try { rmSync(filePath); } catch { /* */ }
+      try { rmSync(filePath + ".lock"); } catch { /* */ }
+      try { rmSync(filePath + ".tmp"); } catch { /* */ }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Extend `TaskCreate` to support batch creation via an optional `batch` array parameter. The existing `subject`/`description` scalar parameters remain fully backward-compatible. Creates multiple tasks in a single atomic tool call — no new tool definition added to the LLM's context window.

## Motivation

When an LLM needs to create several tasks upfront, calling `TaskCreate` N times means N sequential tool-use round-trips, wasting context and time. A batch primitive solves this — Claude Code ships batch creation for exactly this reason.

Rather than adding a new `TaskCreateMany` tool (which would bloat the context with an 8th tool definition), this PR adds a `batch` array parameter to the existing `TaskCreate` tool. The LLM only needs one tool for creating tasks, regardless of count.

See [PR #18](https://github.com/tintinweb/pi-tasks/pull/18) (separate `TaskCreateMany` tool, open) and [PR #16](https://github.com/tintinweb/pi-tasks/pull/16) (batch mutations, closed without merge) for prior approaches. No maintainer comments on either.

## Changes

- **`src/task-store.ts`** — Add `createMany(items)` method: creates multiple tasks inside a single `withLock` call, assigning sequential IDs
- **`src/index.ts`** — Add `batch` array parameter to `TaskCreate` (mutually exclusive with `subject`/`description`). Make `subject` and `description` optional. Add prompt guideline for batch preference. Add validation for mixed-mode and missing-field errors.
- **`README.md`** — Updated `TaskCreate` section with expanded parameter tables for single and batch modes, example JSON, and output format
- **`test/task-store.test.ts`** — 6 new tests for `createMany` (sequential IDs, pending status, metadata, ID counter continuation, empty array, file persistence)
- **`test/subagent-integration.test.ts`** — 10 new tests for `TaskCreate` batch mode (batch creation, TaskList integration, agentType, backward compat, mixed-mode rejection, missing-field rejection, singular wording, atomic appearance)

## Design decisions

1. **Modify existing tool vs. add new tool** — Modifying `TaskCreate` avoids adding an 8th tool definition to the LLM's context window. The tool description already says "create a structured task list" which naturally encompasses batch creation.

2. **`batch` instead of `tasks`** — The parameter is named `batch` rather than `tasks` for discoverability and searchability. `tasks` is too generic and easy to confuse with the concept of tasks; `batch` clearly signals the batch-creation feature.

3. **Mutual exclusivity** — Using both `batch` and `subject`/`description` together returns an error. This keeps the schema unambiguous.

4. **Atomic creation** — Batch tasks are created inside a single `withLock` call, ensuring consistency in file-backed mode (no partial writes when multiple sessions create tasks concurrently).

5. **No dependency wiring in create** — Dependencies should be wired up via `TaskUpdate` after creation. Keeping `TaskCreate` focused on creation only keeps the tool schema simple.
