### PR TITLE
Fix task store writes after parent directory removal

### DIFF
--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -35,6 +35,8 @@ const LOCK_MAX_RETRIES = 100; // 5s max
 
 /** Simple file-based locking. */
 function acquireLock(lockPath: string): void {
+  mkdirSync(dirname(lockPath), { recursive: true });
+
   for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
     try {
       // O_EXCL: fail if file exists
@@ -108,6 +110,7 @@ export class TaskStore {
       nextId: this.nextId,
       tasks: Array.from(this.tasks.values()),
     };
+    mkdirSync(dirname(this.filePath), { recursive: true });
     const tmpPath = this.filePath + ".tmp";
     writeFileSync(tmpPath, JSON.stringify(data, null, 2));
     renameSync(tmpPath, this.filePath);

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -459,5 +459,19 @@ describe("TaskStore (absolute path)", () => {
 
     const raw = JSON.parse(readFileSync(absFilePath, "utf-8"));
     expect(raw.tasks).toHaveLength(2);
+  });
+
+  it("recreates the parent directory before later mutations", () => {
+    const parentDir = join(tmpdir(), `pi-tasks-missing-parent-${Date.now()}`);
+    const filePath = join(parentDir, "tasks.json");
+    const store = new TaskStore(filePath);
+    store.create("Task", "Desc");
+
+    rmSync(parentDir, { recursive: true, force: true });
+
+    expect(() => store.clearCompleted()).not.toThrow();
+    expect(existsSync(filePath)).toBe(true);
+
+    rmSync(parentDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- Prevent task store mutations from failing if the backing store parent directory is removed after initialization.

## Changes
- Recreate the lock parent directory before acquiring a file lock.
- Recreate the store parent directory before writing the temporary file.
- Add a regression test that removes the parent directory between mutations.

## Testing
- npm test
- npm run typecheck
- npm run lint
