### PR TITLE
[fix] Normalize legacy persisted tasks

### DIFF
--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -33,6 +33,28 @@ const TASKS_DIR = join(homedir(), ".pi", "tasks");
 const LOCK_RETRY_MS = 50;
 const LOCK_MAX_RETRIES = 100; // 5s max
 
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+/** Fill defaults for tasks persisted by older pi-tasks versions. */
+function normalizeTask(task: Partial<Task>, now: number): Task {
+  const createdAt = typeof task.createdAt === "number" ? task.createdAt : now;
+  return {
+    id: String(task.id),
+    subject: task.subject ?? "",
+    description: task.description ?? "",
+    status: task.status ?? "pending",
+    activeForm: task.activeForm,
+    owner: task.owner,
+    metadata: task.metadata && typeof task.metadata === "object" && !Array.isArray(task.metadata) ? task.metadata : {},
+    blocks: stringArray(task.blocks),
+    blockedBy: stringArray(task.blockedBy),
+    createdAt,
+    updatedAt: typeof task.updatedAt === "number" ? task.updatedAt : createdAt,
+  };
+}
+
 /** Simple file-based locking. */
 function acquireLock(lockPath: string): void {
   for (let i = 0; i < LOCK_MAX_RETRIES; i++) {
@@ -93,10 +115,12 @@ export class TaskStore {
     if (!existsSync(this.filePath)) return;
     try {
       const data: TaskStoreData = JSON.parse(readFileSync(this.filePath, "utf-8"));
+      const now = Date.now();
       this.nextId = data.nextId;
       this.tasks.clear();
       for (const t of data.tasks) {
-        this.tasks.set(t.id, t);
+        const task = normalizeTask(t, now);
+        this.tasks.set(task.id, task);
       }
     } catch { /* corrupt file — start fresh */ }
   }

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, rmSync } from "node:fs";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -459,5 +459,27 @@ describe("TaskStore (absolute path)", () => {
 
     const raw = JSON.parse(readFileSync(absFilePath, "utf-8"));
     expect(raw.tasks).toHaveLength(2);
+  });
+
+  it("normalizes legacy persisted tasks missing newer fields", () => {
+    writeFileSync(absFilePath, JSON.stringify({
+      nextId: 2,
+      tasks: [{
+        id: "1",
+        subject: "Legacy task",
+        description: "Created before dependency fields existed",
+        status: "pending",
+        createdAt: 1000,
+        updatedAt: 1000,
+      }],
+    }));
+
+    const store = new TaskStore(absFilePath);
+    const task = store.get("1")!;
+
+    expect(task.metadata).toEqual({});
+    expect(task.blocks).toEqual([]);
+    expect(task.blockedBy).toEqual([]);
+    expect(store.create("Next task", "Desc").id).toBe("2");
   });
 });

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskStore } from "../src/task-store.js";
 import { TaskWidget, type Theme, type UICtx } from "../src/ui/task-widget.js";
@@ -120,6 +123,37 @@ describe("TaskWidget", () => {
     const lines = renderWidget(ui.state);
     const blockedLine = lines.find(l => l.includes("Blocked"));
     expect(blockedLine).toContain("blocked by #1");
+  });
+
+  it("renders legacy persisted tasks without dependency arrays", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-tasks-widget-"));
+    const filePath = join(dir, "tasks.json");
+    writeFileSync(filePath, JSON.stringify({
+      nextId: 2,
+      tasks: [{
+        id: "1",
+        subject: "Legacy task",
+        description: "Created before dependency fields existed",
+        status: "pending",
+        createdAt: 1000,
+        updatedAt: 1000,
+      }],
+    }));
+
+    const legacyStore = new TaskStore(filePath);
+    const legacyWidget = new TaskWidget(legacyStore);
+    const legacyUi = mockUICtx();
+    legacyWidget.setUICtx(legacyUi.ctx);
+
+    try {
+      legacyWidget.update();
+      expect(() => renderWidget(legacyUi.state)).not.toThrow();
+      const lines = renderWidget(legacyUi.state);
+      expect(lines[1]).toContain("Legacy task");
+    } finally {
+      legacyWidget.dispose();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("hides completed blockers in blocked-by suffix", () => {


### PR DESCRIPTION

## Issue Details
Pi could exit from an uncaught exception while rendering the task widget:

```text
TypeError: Cannot read properties of undefined (reading length)
at TaskWidget.renderWidget (.../src/ui/task-widget.ts:188:55)
```

The failing path was a persisted legacy task record that did not include newer task fields such as `blockedBy`, `blocks`, or `metadata`. `TaskWidget` and other consumers expect `TaskStore` to return fully-shaped `Task` objects, so reading `task.blockedBy.length` could throw before the UI could recover.

## Purpose
Normalize legacy persisted task data at the `TaskStore` load boundary so every consumer receives canonical task objects. This preserves existing widget/tool behavior while making old task files compatible with the current task schema.

## Summary
- Added load-time normalization for file-backed tasks in `TaskStore`.
- Default missing `metadata` to `{}` and missing dependency arrays to `[]`.
- Preserve existing timestamps and `nextId` behavior for persisted task files.
- Added regression coverage at both the store boundary and widget render path.

## Issue → Solution Flow

```mermaid
flowchart TD
    A[Legacy persisted task file] --> B[TaskStore.load]
    B --> C{Missing newer fields?\nblockedBy / blocks / metadata}
    C -->|Before| D[Raw partial task returned]
    D --> E[TaskWidget.renderWidget]
    E --> F[task.blockedBy.length]
    F --> G[Uncaught TypeError\npi exits]

    C -->|After| H[normalizeTask fills defaults]
    H --> I[Canonical Task object]
    I --> J[Widget and tools read arrays safely]
    J --> K[Task list renders without throwing]
```

## Validation
- [x] Reproduced the failing widget regression before the fix.
- [x] `npm test -- --run test/task-store.test.ts test/task-widget.test.ts` — 80 tests passed.
- [x] `npm run typecheck` — passed.
- [x] `npm run lint` — passed.
- [x] `npm run build` — passed.
- [x] `npm run prepublishOnly` — passed (`lint`, `typecheck`, `test`, `build`; 170 tests).
- [x] Node smoke check confirmed a legacy task is normalized and rendered by the widget without throwing.
- [x] Confirmed installed package source/dist copy matches the `TaskStore` fix for immediate local use.
