### PR TITLE
Fix stale in-progress task reminders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
 } from "./reminder-cadence.js";
 import { TaskStore } from "./task-store.js";
 import { loadTasksConfig } from "./tasks-config.js";
+import type { Task } from "./types.js";
 import { openSettingsMenu } from "./ui/settings-menu.js";
 import { TaskWidget, type UICtx } from "./ui/task-widget.js";
 
@@ -55,9 +56,41 @@ const REMINDER_INTERVAL = 4;
 /** How many turns completed tasks linger before auto-clearing. */
 const AUTO_CLEAR_DELAY = 4;
 
-const SYSTEM_REMINDER = `<system-reminder>
-The task tools haven't been used recently. If you're working on tasks that would benefit from tracking progress, consider using TaskCreate to add new tasks and TaskUpdate to update task status (set to in_progress when starting, completed when done). Also consider cleaning up the task list if it has become stale. Only use these if relevant to the current work. This is just a gentle reminder - ignore if not applicable. Make sure that you NEVER mention this reminder to the user
-</system-reminder>`;
+/** Build a context-aware system reminder that mentions specific in_progress tasks. */
+function buildSystemReminder(tasks: Task[]): string {
+  const inProgress = tasks.filter(t => t.status === "in_progress");
+  const pending = tasks.filter(t => t.status === "pending");
+
+  const lines: string[] = ['<system-reminder>'];
+  lines.push('The task tools haven\'t been used recently.');
+
+  if (inProgress.length > 0) {
+    lines.push('');
+    lines.push('The following task(s) are still marked as in_progress:');
+    for (const t of inProgress) {
+      lines.push(`  #${t.id} — ${t.subject}`);
+    }
+    lines.push('');
+    lines.push('If you have completed any of these, use TaskUpdate to mark them as completed.');
+    lines.push('If they are still in progress, ignore this reminder.');
+  }
+
+  if (pending.length > 0 && inProgress.length === 0) {
+    lines.push('');
+    lines.push('Pending tasks are waiting — use TaskList to check if any are unblocked and ready to start.');
+  }
+
+  if (inProgress.length === 0 && pending.length === 0) {
+    lines.push(' Consider using TaskCreate to track progress if working on multi-step tasks.');
+  }
+
+  lines.push('');
+  lines.push('Only use task tools if relevant to the current work. This is just a gentle reminder — ignore if not applicable.');
+  lines.push('Make sure that you NEVER mention this reminder to the user');
+  lines.push('</system-reminder>');
+
+  return lines.join('\n');
+}
 
 export default function (pi: ExtensionAPI) {
   // Initialize store and config
@@ -306,6 +339,12 @@ export default function (pi: ExtensionAPI) {
   // ── Turn tracking for system-reminder injection ──
   // Cadence decisions live in `reminder-cadence.ts` so they're
   // unit-testable without spinning up a fake ExtensionAPI.
+
+  /** Compute effective reminder interval — shorter when tasks are in_progress. */
+  function effectiveInterval(): number {
+    return store.list().some(t => t.status === "in_progress") ? 2 : REMINDER_INTERVAL;
+  }
+
   const cadence = createCadenceState();
   const cadenceConfig: CadenceConfig = {
     reminderInterval: REMINDER_INTERVAL,
@@ -320,12 +359,29 @@ export default function (pi: ExtensionAPI) {
     if (autoClear.onTurnStart(cadence.currentTurn)) widget.update();
   });
 
-  // ── Token usage tracking ──
+  // ── Token usage tracking + stale-task detection ──
   // Feed per-turn token counts from assistant messages into the widget.
+  // Also detect when the agent has stopped referencing tasks but left
+  // them in_progress — schedule a reminder for the next LLM call.
   pi.on("turn_end", async (event) => {
     const msg = event.message as any;
     if (msg?.role === "assistant" && msg.usage) {
       widget.addTokenUsage(msg.usage.input ?? 0, msg.usage.output ?? 0);
+    }
+
+    // Stale-task detection: if in_progress tasks exist and the agent hasn't
+    // used task tools for >= effectiveInterval turns, schedule a reminder.
+    // This catches the case where the agent completes work without calling
+    // TaskUpdate and then speaks without using any tools.
+    if (!cadence.reminderInjectedThisCycle && !cadence.reminderDue) {
+      const tasks = store.list();
+      const hasInProgress = tasks.some(t => t.status === "in_progress");
+      if (hasInProgress) {
+        const gap = cadence.currentTurn - cadence.lastTaskToolUseTurn;
+        if (gap >= effectiveInterval()) {
+          cadence.reminderDue = true;
+        }
+      }
     }
   });
 
@@ -340,19 +396,22 @@ export default function (pi: ExtensionAPI) {
   // before each LLM call and returns a modified copy of the messages
   // without persisting or polluting any tool output.
   pi.on("tool_result", async (event) => {
-    // Cheap-first: avoid store.list() disk I/O unless the cadence helper
-    // says the call could matter (i.e. it's a task tool that resets state,
-    // or it might queue the reminder).
     const isTaskTool = TASK_TOOL_NAMES.has(event.toolName);
-    if (
-      !isTaskTool &&
-      cadence.currentTurn - cadence.lastTaskToolUseTurn < REMINDER_INTERVAL
-    ) {
+
+    if (isTaskTool) {
+      // Task tool usage resets cadence with the default interval
+      cadenceConfig.reminderInterval = REMINDER_INTERVAL;
+      evaluateToolResult(cadence, event.toolName, false, cadenceConfig);
       return {};
     }
-    if (!isTaskTool && cadence.reminderInjectedThisCycle) return {};
 
-    const hasTasks = isTaskTool ? false : store.list().length > 0;
+    // Non-task tool: use shorter interval when in_progress tasks exist.
+    // Skip if already injected this cycle to avoid unnecessary disk I/O.
+    if (cadence.reminderInjectedThisCycle) return {};
+
+    const tasks = store.list();
+    const hasTasks = tasks.length > 0;
+    cadenceConfig.reminderInterval = effectiveInterval();
     evaluateToolResult(cadence, event.toolName, hasTasks, cadenceConfig);
     return {};
   });
@@ -364,13 +423,14 @@ export default function (pi: ExtensionAPI) {
   // returns a transformed messages array used only for this one request.
   pi.on("context", async (event) => {
     if (!drainReminderForContext(cadence)) return {};
+    const tasks = store.list();
 
     return {
       messages: [
         ...event.messages,
         {
           role: "user" as const,
-          content: [{ type: "text" as const, text: SYSTEM_REMINDER }],
+          content: [{ type: "text" as const, text: buildSystemReminder(tasks) }],
           timestamp: Date.now(),
         },
       ],

--- a/test/stale-task-reminder.test.ts
+++ b/test/stale-task-reminder.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import initExtension from "../src/index.js";
+
+beforeEach(() => { process.env.PI_TASKS = "off"; });
+afterEach(() => { delete process.env.PI_TASKS; });
+
+function mockCtx() {
+  return {
+    model: { id: "test-model", name: "Test" },
+    modelRegistry: {},
+    ui: {
+      setWidget: vi.fn(),
+      setStatus: vi.fn(),
+      notify: vi.fn(),
+    },
+  };
+}
+
+function mockPi() {
+  const tools = new Map<string, any>();
+  const eventHandlers = new Map<string, ((data: unknown) => void)[]>();
+  const lifecycleHandlers = new Map<string, ((...args: any[]) => any)[]>();
+
+  const pi = {
+    registerTool(def: any) { tools.set(def.name, def); },
+    registerCommand: vi.fn(),
+    on(event: string, handler: any) {
+      if (!lifecycleHandlers.has(event)) lifecycleHandlers.set(event, []);
+      lifecycleHandlers.get(event)!.push(handler);
+    },
+    events: {
+      emit(channel: string, data: unknown) {
+        for (const h of eventHandlers.get(channel) ?? []) h(data);
+      },
+      on(channel: string, handler: (data: unknown) => void) {
+        if (!eventHandlers.has(channel)) eventHandlers.set(channel, []);
+        eventHandlers.get(channel)!.push(handler);
+        return () => {
+          const arr = eventHandlers.get(channel);
+          if (arr) eventHandlers.set(channel, arr.filter(h => h !== handler));
+        };
+      },
+    },
+  };
+
+  return {
+    pi,
+    tools,
+    async executeTool(name: string, params: any, ctx = mockCtx()) {
+      const tool = tools.get(name);
+      if (!tool) throw new Error(`Tool ${name} not registered`);
+      const result = await tool.execute("call-1", params, undefined, undefined, ctx);
+      await this.fireLifecycle("tool_result", { toolName: name });
+      return result;
+    },
+    async fireLifecycle(event: string, ...args: any[]) {
+      let lastResult: any;
+      for (const h of lifecycleHandlers.get(event) ?? []) {
+        const result = await h(...args);
+        if (result !== undefined) lastResult = result;
+      }
+      return lastResult;
+    },
+  };
+}
+
+function installPingResponder(pi: ReturnType<typeof mockPi>["pi"]) {
+  return pi.events.on("subagents:rpc:ping", (data: unknown) => {
+    const { requestId } = data as { requestId: string };
+    pi.events.emit(`subagents:rpc:ping:reply:${requestId}`, { success: true, data: { version: 2 } });
+  });
+}
+
+describe("stale in_progress task reminders", () => {
+  it("injects a task-specific reminder after text-only turns", async () => {
+    const mock = mockPi();
+    const unping = installPingResponder(mock.pi);
+    initExtension(mock.pi as any);
+
+    await mock.executeTool("TaskCreate", { subject: "Finish stale reminder test", description: "Desc" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
+
+    await mock.fireLifecycle("turn_start", {}, mockCtx());
+    await mock.fireLifecycle("turn_end", { message: { role: "assistant", usage: { input: 1, output: 1 } } });
+    let contextResult = await mock.fireLifecycle("context", { messages: [] });
+    expect(contextResult).toEqual({});
+
+    await mock.fireLifecycle("turn_start", {}, mockCtx());
+    await mock.fireLifecycle("turn_end", { message: { role: "assistant", usage: { input: 1, output: 1 } } });
+    contextResult = await mock.fireLifecycle("context", { messages: [] });
+
+    const reminder = contextResult.messages.at(-1).content[0].text;
+    expect(reminder).toContain("#1 — Finish stale reminder test");
+    expect(reminder).toContain("still marked as in_progress");
+    expect(reminder).toContain("use TaskUpdate to mark them as completed");
+
+    unping();
+  });
+
+  it("uses a shorter reminder interval for non-task tools when a task is in_progress", async () => {
+    const mock = mockPi();
+    const unping = installPingResponder(mock.pi);
+    initExtension(mock.pi as any);
+
+    await mock.executeTool("TaskCreate", { subject: "Run validation", description: "Desc" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
+
+    await mock.fireLifecycle("turn_start", {}, mockCtx());
+    await mock.fireLifecycle("tool_result", { toolName: "read" });
+    let contextResult = await mock.fireLifecycle("context", { messages: [] });
+    expect(contextResult).toEqual({});
+
+    await mock.fireLifecycle("turn_start", {}, mockCtx());
+    await mock.fireLifecycle("tool_result", { toolName: "bash" });
+    contextResult = await mock.fireLifecycle("context", { messages: [] });
+
+    const reminder = contextResult.messages.at(-1).content[0].text;
+    expect(reminder).toContain("#1 — Run validation");
+    expect(reminder).toContain("If you have completed any of these");
+
+    unping();
+  });
+});


### PR DESCRIPTION
## Summary

This change makes task reminders context-aware and more responsive when tasks remain marked as `in_progress`.

Previously, pi-tasks injected a generic reminder after several turns without task-tool usage. That could be easy for agents to overlook, especially after finishing implementation work but forgetting to call `TaskUpdate` to mark the active task as completed.

This PR improves that flow by:

- replacing the static reminder with a context-aware reminder that lists specific `in_progress` tasks by ID and subject
- using a shorter reminder interval when any task is currently `in_progress`
- adding `turn_end` stale-task detection so reminders are still scheduled when the assistant replies without using any tools
- keeping the reminder non-mutating: task state is never auto-completed, avoiding false positives

## Why

The failure mode this addresses is: an agent creates or starts a task, completes the actual work, but forgets to update the task status. The stale `in_progress` task can then remain visible indefinitely.

This implementation avoids automatic status changes and instead nudges the assistant with precise task context, making it more likely to update the correct task while preserving safety.

## Testing

- `npm run typecheck`
- `npm test`
- `npm run lint`
