### PR TITLE
fix:rehydrate tasks on reload

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -377,22 +377,44 @@ export default function (pi: ExtensionAPI) {
     };
   });
 
-  // Rehydrate before the first turn as well as after /reload. A reload creates a
-  // fresh extension instance, and before_agent_start does not fire until the user
-  // submits another prompt, which would otherwise leave persisted tasks hidden.
+  // session_start replaces the never-emitted session_switch event. Rehydrating
+  // here matters because before_agent_start only fires once the user prompts.
   pi.on("session_start", async (event, ctx) => {
     latestCtx = ctx;
     widget.setUICtx(ctx.ui as UICtx);
-    upgradeStoreIfNeeded(ctx);
-    showPersistedTasks(event.reason === "reload" || event.reason === "resume");
+
+    const reason = event.reason;
+    // new/resume/fork reuse the running extension instance (getExtensions() is
+    // cached), so session-scoped state must be reset. startup/reload re-run the
+    // factory and start clean.
+    const isSwitch = reason === "new" || reason === "resume" || reason === "fork";
+    // A fork branches the conversation, so its tasks carry over as an independent
+    // copy. Snapshot before the store re-points to the new (empty) session file.
+    const forkSeed = reason === "fork" ? store.snapshot() : undefined;
+    if (isSwitch) {
+      storeUpgraded = false;
+      persistedTasksShown = false;
+      resetCadenceState(cadence);
+      autoClear.reset();
+      // Memory mode has no file to switch — clear tasks explicitly on /new.
+      if (reason === "new" && taskScope === "memory") {
+        store.clearAll();
+      }
+    }
+
+    upgradeStoreIfNeeded(ctx); // re-points a session store once storeUpgraded is cleared
+    if (forkSeed?.tasks.length) store.seed(forkSeed); // carry the parent's tasks into the fork
+    // resume/reload/fork keep tasks; startup/new auto-clear an all-completed list.
+    showPersistedTasks(reason === "reload" || reason === "resume" || reason === "fork");
+
     if (pendingWarning) {
       ctx.ui.notify(pendingWarning, "warning");
       pendingWarning = undefined;
     }
   });
 
-  // Keep this fallback for hosts that initialize UI lazily and for the first
-  // agent turn on older pi versions.
+  // Fallback for hosts that init UI lazily. Guarded by persistedTasksShown, so
+  // it never double-renders after session_start.
   pi.on("before_agent_start", async (_event, ctx) => {
     latestCtx = ctx;
     widget.setUICtx(ctx.ui as UICtx);
@@ -402,30 +424,6 @@ export default function (pi: ExtensionAPI) {
       ctx.ui.notify(pendingWarning, "warning");
       pendingWarning = undefined;
     }
-  });
-
-  // session_switch fires on /new (reason: "new") and /resume (reason: "resume").
-  // On /new: reset all session-scoped state so the store switches to the new session file.
-  // On resume: reload persisted tasks from the existing session file.
-  pi.on("session_switch" as any, async (event: any, ctx: ExtensionContext) => {
-    latestCtx = ctx;
-    widget.setUICtx(ctx.ui as UICtx);
-
-    const isResume = event?.reason === "resume";
-
-    // Reset session-scoped state for both /new and /resume
-    storeUpgraded = false;
-    persistedTasksShown = false;
-    resetCadenceState(cadence);
-    autoClear.reset();
-
-    // Memory mode has no file-backed store to switch — clear explicitly on /new
-    if (!isResume && taskScope === "memory") {
-      store.clearAll();
-    }
-
-    upgradeStoreIfNeeded(ctx);
-    showPersistedTasks(isResume);
   });
 
   // Keep latestCtx fresh on every tool execution as well.

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,8 +377,22 @@ export default function (pi: ExtensionAPI) {
     };
   });
 
-  // Grab UI context early — before_agent_start fires before any tool calls,
-  // so persisted tasks show up immediately on session start.
+  // Rehydrate before the first turn as well as after /reload. A reload creates a
+  // fresh extension instance, and before_agent_start does not fire until the user
+  // submits another prompt, which would otherwise leave persisted tasks hidden.
+  pi.on("session_start", async (event, ctx) => {
+    latestCtx = ctx;
+    widget.setUICtx(ctx.ui as UICtx);
+    upgradeStoreIfNeeded(ctx);
+    showPersistedTasks(event.reason === "reload" || event.reason === "resume");
+    if (pendingWarning) {
+      ctx.ui.notify(pendingWarning, "warning");
+      pendingWarning = undefined;
+    }
+  });
+
+  // Keep this fallback for hosts that initialize UI lazily and for the first
+  // agent turn on older pi versions.
   pi.on("before_agent_start", async (_event, ctx) => {
     latestCtx = ctx;
     widget.setUICtx(ctx.ui as UICtx);

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -293,6 +293,23 @@ export class TaskStore {
     });
   }
 
+  /** Capture full store state — used to carry tasks into a forked session. */
+  snapshot(): TaskStoreData {
+    if (this.filePath) this.load();
+    return { nextId: this.nextId, tasks: Array.from(this.tasks.values()) };
+  }
+
+  /** Seed an empty store from a snapshot. No-op if the store already has tasks,
+   *  so re-pointing to an already-seeded fork file never duplicates. */
+  seed(data: TaskStoreData): void {
+    if (this.tasks.size > 0) return;
+    this.withLock(() => {
+      this.nextId = data.nextId;
+      this.tasks.clear();
+      for (const t of data.tasks) this.tasks.set(t.id, t);
+    });
+  }
+
   /** Delete the backing file (if file-backed and empty). */
   deleteFileIfEmpty(): boolean {
     if (!this.filePath || this.tasks.size > 0) return false;

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -3,6 +3,9 @@
  * auto-cascade, and widget agent ID display.
  */
 
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import initExtension from "../src/index.js";
 import { TaskStore } from "../src/task-store.js";
@@ -85,6 +88,26 @@ function mockCtx() {
     },
   };
 }
+
+describe("Session task rehydration", () => {
+  it("renders persisted tasks immediately after reload", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "pi-tasks-reload-"));
+    const taskFile = join(directory, "tasks.json");
+    try {
+      new TaskStore(taskFile).create("Review the rerun", "Inspect final results");
+      process.env.PI_TASKS = taskFile;
+      const mock = mockPi();
+      initExtension(mock.pi as any);
+      const ctx = mockCtx();
+
+      await mock.fireLifecycle("session_start", { reason: "reload" }, ctx);
+
+      expect(ctx.ui.setWidget).toHaveBeenCalled();
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});
 
 // ---- Mock subagents extension (RPC responders) ----
 

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -90,7 +90,31 @@ function mockCtx() {
 }
 
 describe("Session task rehydration", () => {
-  it("renders persisted tasks immediately after reload", async () => {
+  it("renders default session-scoped tasks immediately after reload", async () => {
+    const sessionId = `reload-${process.pid}-${Date.now()}`;
+    const taskFile = join(process.cwd(), ".pi", "tasks", `tasks-${sessionId}.json`);
+    try {
+      new TaskStore(taskFile).create("Review the rerun", "Inspect final results");
+      delete process.env.PI_TASKS;
+      const mock = mockPi();
+      initExtension(mock.pi as any);
+      const ctx = {
+        ...mockCtx(),
+        sessionManager: { getSessionId: vi.fn(() => sessionId) },
+      };
+
+      await mock.fireLifecycle("session_start", { reason: "reload" }, ctx);
+
+      expect(ctx.sessionManager.getSessionId).toHaveBeenCalledOnce();
+      expect(ctx.ui.setWidget).toHaveBeenCalledWith("tasks", expect.any(Function), {
+        placement: "aboveEditor",
+      });
+    } finally {
+      rmSync(taskFile, { force: true });
+    }
+  });
+
+  it("renders tasks from a PI_TASKS path override after reload", async () => {
     const directory = mkdtempSync(join(tmpdir(), "pi-tasks-reload-"));
     const taskFile = join(directory, "tasks.json");
     try {
@@ -102,7 +126,9 @@ describe("Session task rehydration", () => {
 
       await mock.fireLifecycle("session_start", { reason: "reload" }, ctx);
 
-      expect(ctx.ui.setWidget).toHaveBeenCalled();
+      expect(ctx.ui.setWidget).toHaveBeenCalledWith("tasks", expect.any(Function), {
+        placement: "aboveEditor",
+      });
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -133,6 +133,90 @@ describe("Session task rehydration", () => {
       rmSync(directory, { recursive: true, force: true });
     }
   });
+
+  it("renders persisted tasks after /resume", async () => {
+    const sessionId = `resume-${process.pid}-${Date.now()}`;
+    const taskFile = join(process.cwd(), ".pi", "tasks", `tasks-${sessionId}.json`);
+    try {
+      new TaskStore(taskFile).create("Resume this", "Pick up where we left off");
+      delete process.env.PI_TASKS;
+      const mock = mockPi();
+      initExtension(mock.pi as any);
+      const ctx = {
+        ...mockCtx(),
+        sessionManager: { getSessionId: vi.fn(() => sessionId) },
+      };
+
+      await mock.fireLifecycle("session_start", { reason: "resume" }, ctx);
+
+      expect(ctx.ui.setWidget).toHaveBeenCalledWith("tasks", expect.any(Function), {
+        placement: "aboveEditor",
+      });
+    } finally {
+      rmSync(taskFile, { force: true });
+    }
+  });
+
+  it("switches the session-scoped store to the new session on /new", async () => {
+    const sessionA = `switch-a-${process.pid}-${Date.now()}`;
+    const sessionB = `switch-b-${process.pid}-${Date.now()}`;
+    const fileA = join(process.cwd(), ".pi", "tasks", `tasks-${sessionA}.json`);
+    const fileB = join(process.cwd(), ".pi", "tasks", `tasks-${sessionB}.json`);
+    try {
+      new TaskStore(fileA).create("Task in A", "desc");
+      new TaskStore(fileB).create("Task in B", "desc");
+      delete process.env.PI_TASKS;
+      const mock = mockPi();
+      initExtension(mock.pi as any);
+
+      const ctxA = { ...mockCtx(), sessionManager: { getSessionId: vi.fn(() => sessionA) } };
+      await mock.fireLifecycle("session_start", { reason: "startup" }, ctxA);
+      expect(ctxA.sessionManager.getSessionId).toHaveBeenCalledOnce();
+
+      // /new must reset storeUpgraded and re-point at the new session file —
+      // previously handled by the (never-emitted) session_switch event. Without
+      // that reset, storeUpgraded stays true and getSessionId is never called
+      // again, leaving the store stuck on session A.
+      const ctxB = { ...mockCtx(), sessionManager: { getSessionId: vi.fn(() => sessionB) } };
+      await mock.fireLifecycle("session_start", { reason: "new" }, ctxB);
+      expect(ctxB.sessionManager.getSessionId).toHaveBeenCalledOnce();
+    } finally {
+      rmSync(fileA, { force: true });
+      rmSync(fileB, { force: true });
+    }
+  });
+
+  it("seeds a forked session with an independent copy of the parent's tasks", async () => {
+    const parent = `fork-parent-${process.pid}-${Date.now()}`;
+    const child = `fork-child-${process.pid}-${Date.now()}`;
+    const parentFile = join(process.cwd(), ".pi", "tasks", `tasks-${parent}.json`);
+    const childFile = join(process.cwd(), ".pi", "tasks", `tasks-${child}.json`);
+    try {
+      new TaskStore(parentFile).create("Inherited task", "carry me into the fork");
+      delete process.env.PI_TASKS;
+      const mock = mockPi();
+      initExtension(mock.pi as any);
+
+      const ctxP = { ...mockCtx(), sessionManager: { getSessionId: vi.fn(() => parent) } };
+      await mock.fireLifecycle("session_start", { reason: "startup" }, ctxP);
+
+      // /fork re-points to a brand-new (empty) session file. Without seeding, the
+      // fork would silently lose the parent's tasks; with it, the fork gets an
+      // independent copy that does not write back to the parent.
+      const ctxC = { ...mockCtx(), sessionManager: { getSessionId: vi.fn(() => child) } };
+      await mock.fireLifecycle("session_start", { reason: "fork" }, ctxC);
+
+      const forked = new TaskStore(childFile).list();
+      expect(forked.map(t => t.subject)).toEqual(["Inherited task"]);
+
+      // The fork is independent — mutating it must not touch the parent's file.
+      new TaskStore(childFile).create("Fork-only task", "not in parent");
+      expect(new TaskStore(parentFile).list().map(t => t.subject)).toEqual(["Inherited task"]);
+    } finally {
+      rmSync(parentFile, { force: true });
+      rmSync(childFile, { force: true });
+    }
+  });
 });
 
 // ---- Mock subagents extension (RPC responders) ----


### PR DESCRIPTION
When resuming a session, tasks don't show up - even though they are saved. Tested across session/project level setting