### PR TITLE
"fix(store): create the task directory lazily, on first write

### DIFF
--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -83,7 +83,8 @@ export class TaskStore {
     if (!listIdOrPath) return;
     const isAbsPath = isAbsolute(listIdOrPath);
     const filePath = isAbsPath ? listIdOrPath : join(TASKS_DIR, `${listIdOrPath}.json`);
-    mkdirSync(dirname(filePath), { recursive: true });
+    // Directory is created lazily on the first write (acquireLock/save both
+    // mkdir it), so a session that never persists a task leaves no .pi/tasks/.
     this.filePath = filePath;
     this.lockPath = filePath + ".lock";
     this.load();

--- a/test/task-store.test.ts
+++ b/test/task-store.test.ts
@@ -474,4 +474,22 @@ describe("TaskStore (absolute path)", () => {
 
     rmSync(parentDir, { recursive: true, force: true });
   });
+
+  it("creates the backing directory lazily — not on construction, but on first write", () => {
+    const parentDir = join(tmpdir(), `pi-tasks-lazy-${Date.now()}`);
+    const filePath = join(parentDir, "tasks.json");
+    try {
+      const store = new TaskStore(filePath);
+      // Constructing a store must not create the directory for a session that
+      // never persists a task.
+      expect(existsSync(parentDir)).toBe(false);
+
+      store.create("Task", "Desc");
+      // The first mutation creates it.
+      expect(existsSync(parentDir)).toBe(true);
+      expect(existsSync(filePath)).toBe(true);
+    } finally {
+      rmSync(parentDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## What

`TaskStore` created its backing directory (`.pi/tasks/`) eagerly in the constructor — even for sessions that never persist a task. This defers creation to the **first write**, so a session with no tasks leaves no empty `.pi/tasks/` behind.

The directory still gets created exactly when needed: `acquireLock()` and `save()` already `mkdir(..., { recursive: true })` on every mutation (from #27), so nothing else had to change. The constructor's `mkdirSync` was redundant.

## Why it's safe

- Nothing reads or writes the backing directory between `new TaskStore(...)` and the first mutation. `load()`/`list()`/`get()` are `existsSync`-guarded (a missing dir just yields an empty list); every mutation routes through `withLock` → `acquireLock`/`save`, which create the dir.
- Verified end-to-end against the real filesystem: construct → no dir; read → still no dir; first `create()` → dir + file appear; reload → task persists.

## Existing users

Purely subtractive. Task creation, listing, persistence, locking, and resume are unchanged, and existing `.pi/tasks/` data is untouched. The only observable difference: a session that never creates a task no longer leaves an empty directory.

## Relationship to #32

Extracted from #32 (thanks @jalaxy33) — this takes the **lazy-creation** half only. The auto-cleanup half (`rmdir` of `.pi/tasks/` and `.pi/` on session end) is intentionally **not** included. Closes #32.

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — all pass, including a new test asserting the dir is not created on construction but is created on first write
- `npx biome check src/ test/` — clean