### PR TITLE
fix(widget): repair active task firework animation

### DIFF
--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -43,8 +43,20 @@ export type UICtx = {
   ): void;
 };
 
-/** Star spinner frames for animated active task indicator (matches Claude Code). */
-const SPINNER = ["✳", "✴", "✵", "✶", "✷", "✸", "✹", "✺", "✻", "✼", "✽"];
+/** Firework frames for the animated active task indicator (matches Claude Code). */
+const GHOSTTY_FIREWORK_BASE = ["·", "✢", "✳", "✶", "✻", "*"] as const;
+const DARWIN_FIREWORK_BASE = ["·", "✢", "✳", "✶", "✻", "✽"] as const;
+const PORTABLE_FIREWORK_BASE = ["·", "✢", "*", "✶", "✻", "✽"] as const;
+const FIREWORK_INTERVAL_MS = 120;
+
+function getFireworkBaseFrames(): readonly string[] {
+  if (process.env.TERM === "xterm-ghostty") return GHOSTTY_FIREWORK_BASE;
+  return process.platform === "darwin" ? DARWIN_FIREWORK_BASE : PORTABLE_FIREWORK_BASE;
+}
+
+function buildFireworkFrames(base: readonly string[]): readonly string[] {
+  return [...base, ...[...base].reverse()];
+}
 
 const DEFAULT_MAX_VISIBLE_TASKS = 10;
 
@@ -77,7 +89,8 @@ function formatTokens(n: number): string {
 
 export class TaskWidget {
   private uiCtx: UICtx | undefined;
-  private widgetFrame = 0;
+  private fireworkFrame = 0;
+  private readonly fireworkFrames = buildFireworkFrames(getFireworkBaseFrames());
   private widgetInterval: ReturnType<typeof setInterval> | undefined;
   /** IDs of tasks currently being actively executed (show spinner). */
   private activeTaskIds = new Set<string>();
@@ -104,6 +117,10 @@ export class TaskWidget {
   /** Add or remove a task from the active spinner set. */
   setActiveTask(taskId: string | undefined, active = true) {
     if (taskId && active) {
+      const hasActiveTask = [...this.activeTaskIds].some(id => this.store.get(id)?.status === "in_progress");
+      if (!hasActiveTask) {
+        this.fireworkFrame = 0;
+      }
       this.activeTaskIds.add(taskId);
       if (!this.metrics.has(taskId)) {
         this.metrics.set(taskId, { startedAt: Date.now(), inputTokens: 0, outputTokens: 0 });
@@ -130,7 +147,10 @@ export class TaskWidget {
   /** Ensure the widget update timer is running. */
   ensureTimer() {
     if (!this.widgetInterval) {
-      this.widgetInterval = setInterval(() => this.update(), 150);
+      this.widgetInterval = setInterval(() => {
+        this.fireworkFrame = (this.fireworkFrame + 1) % this.fireworkFrames.length;
+        this.update();
+      }, FIREWORK_INTERVAL_MS);
     }
   }
 
@@ -164,7 +184,7 @@ export class TaskWidget {
     if (pending.length > 0) parts.push(`${pending.length} open`);
     const statusText = `${tasks.length} tasks (${parts.join(", ")})`;
 
-    const spinnerChar = SPINNER[this.widgetFrame % SPINNER.length];
+    const spinnerChar = this.fireworkFrames[this.fireworkFrame];
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
     const showAll = this.config.showAll ?? false;
@@ -277,8 +297,6 @@ export class TaskWidget {
       clearInterval(this.widgetInterval);
       this.widgetInterval = undefined;
     }
-
-    this.widgetFrame++;
 
     // Transition: hidden → visible — register widget callback once
     if (!this.widgetRegistered) {

--- a/test/task-widget.test.ts
+++ b/test/task-widget.test.ts
@@ -43,6 +43,34 @@ function renderWidget(state: ReturnType<typeof mockUICtx>["state"]): string[] {
   return result.render();
 }
 
+function activeIcons(lines: string[]): string[] {
+  return lines.slice(1).map(line => line.trimStart().split(" ")[0]);
+}
+
+async function renderAnimationCycle(platform: NodeJS.Platform, term: string): Promise<string[]> {
+  vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+  vi.stubEnv("TERM", term);
+  vi.resetModules();
+  const { TaskWidget: PlatformTaskWidget } = await import("../src/ui/task-widget.js");
+
+  const cycleStore = new TaskStore();
+  const cycleUI = mockUICtx();
+  const cycleWidget = new PlatformTaskWidget(cycleStore);
+  cycleWidget.setUICtx(cycleUI.ctx);
+  cycleStore.create("Animated task", "Desc", "Animating");
+  cycleStore.update("1", { status: "in_progress" });
+  cycleWidget.setActiveTask("1", true);
+
+  const frames = [activeIcons(renderWidget(cycleUI.state))[0]];
+  for (let index = 1; index < 12; index++) {
+    vi.advanceTimersByTime(120);
+    frames.push(activeIcons(renderWidget(cycleUI.state))[0]);
+  }
+  cycleWidget.dispose();
+  vi.restoreAllMocks();
+  return frames;
+}
+
 describe("TaskWidget", () => {
   let store: TaskStore;
   let widget: TaskWidget;
@@ -58,6 +86,8 @@ describe("TaskWidget", () => {
 
   afterEach(() => {
     widget.dispose();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
@@ -109,6 +139,96 @@ describe("TaskWidget", () => {
     expect(lines[1]).toContain("Processing data…");
     // Should NOT show ◼ for active task
     expect(lines[1]).not.toContain("◼");
+  });
+
+  it.each([
+    {
+      name: "Ghostty with platform precedence",
+      platform: "darwin" as NodeJS.Platform,
+      term: "xterm-ghostty",
+      expected: ["·", "✢", "✳", "✶", "✻", "*", "*", "✻", "✶", "✳", "✢", "·"],
+    },
+    {
+      name: "macOS outside Ghostty",
+      platform: "darwin" as NodeJS.Platform,
+      term: "xterm-256color",
+      expected: ["·", "✢", "✳", "✶", "✻", "✽", "✽", "✻", "✶", "✳", "✢", "·"],
+    },
+    {
+      name: "other platforms",
+      platform: "linux" as NodeJS.Platform,
+      term: "xterm-256color",
+      expected: ["·", "✢", "*", "✶", "✻", "✽", "✽", "✻", "✶", "*", "✢", "·"],
+    },
+  ])("renders the complete $name firework cycle", async ({ platform, term, expected }) => {
+    expect(await renderAnimationCycle(platform, term)).toEqual(expected);
+  });
+
+  it("advances the firework only on 120ms timer ticks", () => {
+    store.create("Running thing", "Desc", "Processing data");
+    store.update("1", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+
+    const initialLines = renderWidget(ui.state);
+    expect(activeIcons(initialLines)).toEqual(["·"]);
+    expect(initialLines[1]).toMatch(/^\s{2}· #1 /);
+    widget.update();
+    widget.update();
+    expect(activeIcons(renderWidget(ui.state))).toEqual(["·"]);
+
+    vi.advanceTimersByTime(119);
+    expect(activeIcons(renderWidget(ui.state))).toEqual(["·"]);
+    vi.advanceTimersByTime(1);
+    expect(activeIcons(renderWidget(ui.state))).toEqual(["✢"]);
+  });
+
+  it("shares one timer and one lockstep phase across active tasks", () => {
+    store.create("Task A", "Desc", "Processing A");
+    store.create("Task B", "Desc", "Processing B");
+    store.update("1", { status: "in_progress" });
+    store.update("2", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+
+    expect(vi.getTimerCount()).toBe(1);
+    vi.advanceTimersByTime(120);
+    widget.setActiveTask("2", true);
+
+    expect(vi.getTimerCount()).toBe(1);
+    expect(activeIcons(renderWidget(ui.state))).toEqual(["✢", "✢"]);
+  });
+
+  it("stops after the last active task and restarts from the first frame", () => {
+    store.create("Task A", "Desc", "Processing A");
+    store.create("Task B", "Desc", "Processing B");
+    store.update("1", { status: "in_progress" });
+    store.update("2", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+    widget.setActiveTask("2", true);
+    vi.advanceTimersByTime(120);
+
+    widget.setActiveTask("1", false);
+    expect(vi.getTimerCount()).toBe(1);
+    widget.setActiveTask("2", false);
+    expect(vi.getTimerCount()).toBe(0);
+
+    widget.setActiveTask("1", true);
+    expect(vi.getTimerCount()).toBe(1);
+    expect(activeIcons(renderWidget(ui.state))).toEqual(["·", "◼"]);
+  });
+
+  it("restarts from the first frame after the last active task becomes completed", () => {
+    store.create("Task A", "Desc", "Processing A");
+    store.create("Task B", "Desc", "Processing B");
+    store.update("1", { status: "in_progress" });
+    store.update("2", { status: "in_progress" });
+    widget.setActiveTask("1", true);
+    vi.advanceTimersByTime(120);
+
+    store.update("1", { status: "completed" });
+    widget.setActiveTask("2", true);
+
+    expect(vi.getTimerCount()).toBe(1);
+    expect(activeIcons(renderWidget(ui.state))).toEqual(["✔", "·"]);
   });
 
   it("shows blocked-by info for pending tasks", () => {


### PR DESCRIPTION
## Summary

- replace the uneven eleven-Dingbat active-task spinner with Claude Code's mirrored expanding/contracting firework sequence
- select Claude-compatible one-cell center glyphs for Ghostty, macOS, and other terminals
- start deterministically at `·` and advance only on the 120 ms animation timer while preserving the existing task-row layout and behavior
- keep one instance-owned timer and a shared lockstep phase across active tasks

## Validation

- `npx vitest run test/task-widget.test.ts` — 43 passed
- `npm test` — 198 passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- independent review: approved, no Critical or Important findings

## Scope

Code and tests only: `src/ui/task-widget.ts` and `test/task-widget.test.ts`. No README or changelog changes.
