### PR TITLE
fix: clear completed task lists immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`on_list_complete` now clears synchronously** when the final task completes, rather than waiting for four future turns. This prevents a finished batch from accumulating indefinitely when new work starts before the delayed cleanup fires. Stale all-completed lists are also cleared on resume/reload in this mode.
+
 ## [0.7.2] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ pending → in_progress → completed
                       → deleted (permanently removed)
 ```
 
-Tasks are created as `pending`. Mark `in_progress` before starting work, `completed` when done. `deleted` removes entirely — IDs never reset.
+Tasks are created as `pending`. Mark `in_progress` before starting work, `completed` when done. `deleted` removes entirely — IDs never reset. With the default `on_list_complete` cleanup mode, completing the final task immediately clears the whole tracker.
 
 ## Dependency Management
 
@@ -201,7 +201,7 @@ Task storage is controlled by the `taskScope` setting (`/tasks` → Settings →
 | `session` **(default)** | `<cwd>/.pi/tasks/tasks-<sessionId>.json` | Per-session file — isolated between sessions, survives resume |
 | `project` | `<cwd>/.pi/tasks/tasks.json` | Shared across all sessions in the project |
 
-On new session start, if all persisted tasks are completed they are auto-cleared for a clean slate. On session resume, all tasks (including completed) are shown so the user can review progress. Empty session files are automatically deleted when all tasks are cleared.
+On new session start, if all persisted tasks are completed they are auto-cleared for a clean slate. On session resume, unfinished work is restored; an all-completed list is also cleared when `on_list_complete` is active, while the other cleanup modes preserve it for review. Empty session files are automatically deleted when all tasks are cleared.
 
 ### Auto-clear completed tasks
 
@@ -210,10 +210,10 @@ The `autoClearCompleted` setting controls automatic cleanup of completed tasks:
 | Mode | Behaviour |
 |------|-----------|
 | `never` | Completed tasks stay visible until manually cleared via `/tasks` → Clear completed |
-| `on_list_complete` **(default)** | Cleared after all tasks are done and a few idle turns pass |
-| `on_task_complete` | Each completed task cleared individually after a few turns |
+| `on_list_complete` **(default)** | The whole tracker clears immediately when its final task completes |
+| `on_task_complete` | Each completed task clears individually after a few turns |
 
-Both auto-clear modes use a turn-based delay for non-jarring UX — tasks linger briefly so you see the completion before they disappear.
+The per-task mode uses a short turn-based delay so individual completions remain visible briefly. The default list mode clears synchronously, preventing a finished batch from being carried into the next batch.
 
 Settings (`taskScope`, `autoCascade`, `autoClearCompleted`, plus the [widget display settings](#widget-display-settings) `sortOrder` / `maxVisible` / `showAll` / `hiddenAt`) changed through `/tasks` are saved as project overrides in `<cwd>/.pi/tasks-config.json`.
 

--- a/src/auto-clear.ts
+++ b/src/auto-clear.ts
@@ -1,11 +1,9 @@
 /**
- * auto-clear.ts — Turn-based auto-clearing of completed tasks.
+ * auto-clear.ts — Auto-clearing of completed tasks.
  *
  * Two modes:
- * - "on_task_complete": each completed task gets its own REMINDER_INTERVAL countdown, deleted individually
- * - "on_list_complete": countdown starts when ALL tasks are completed, cleared as a batch
- *
- * Both use the same turn delay (REMINDER_INTERVAL) for consistency.
+ * - "on_task_complete": each completed task gets its own turn countdown, then is deleted individually
+ * - "on_list_complete": the whole list is cleared immediately when its final task completes
  */
 
 import type { TaskStore } from "./task-store.js";
@@ -15,13 +13,11 @@ export type AutoClearMode = "never" | "on_list_complete" | "on_task_complete";
 export class AutoClearManager {
   /** Per-task: turn when task was marked completed ("on_task_complete" mode). */
   private completedAtTurn = new Map<string, number>();
-  /** Turn when ALL tasks became completed ("on_list_complete" mode). */
-  private allCompletedAtTurn: number | null = null;
 
   constructor(
     private getStore: () => TaskStore,
     private getMode: () => AutoClearMode,
-    /** How many turns completed tasks linger before auto-clearing. */
+    /** How many turns individual completed tasks linger before auto-clearing. */
     private clearDelayTurns = 4,
   ) {}
 
@@ -33,29 +29,17 @@ export class AutoClearManager {
     if (mode === "on_task_complete") {
       this.completedAtTurn.set(taskId, currentTurn);
     } else if (mode === "on_list_complete") {
-      this.checkAllCompleted(currentTurn);
+      const store = this.getStore();
+      const tasks = store.list();
+      if (tasks.length > 0 && tasks.every(t => t.status === "completed")) {
+        store.clearCompleted();
+      }
     }
-  }
-
-  /** Check if all tasks are completed and start/reset the batch countdown. */
-  private checkAllCompleted(currentTurn: number): void {
-    const tasks = this.getStore().list();
-    if (tasks.length > 0 && tasks.every(t => t.status === "completed")) {
-      if (this.allCompletedAtTurn === null) this.allCompletedAtTurn = currentTurn;
-    } else {
-      this.allCompletedAtTurn = null;
-    }
-  }
-
-  /** Reset batch countdown (e.g., when a new task is created or task goes non-completed). */
-  resetBatchCountdown(): void {
-    this.allCompletedAtTurn = null;
   }
 
   /** Reset all tracking state (e.g., on new session). */
   reset(): void {
     this.completedAtTurn.clear();
-    this.allCompletedAtTurn = null;
   }
 
   /**
@@ -77,12 +61,6 @@ export class AutoClearManager {
           this.completedAtTurn.delete(taskId);
           cleared = true;
         }
-      }
-    } else if (mode === "on_list_complete" && this.allCompletedAtTurn !== null) {
-      if (currentTurn - this.allCompletedAtTurn >= this.clearDelayTurns) {
-        this.getStore().clearCompleted();
-        this.allCompletedAtTurn = null;
-        cleared = true;
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ function intervalFor(tasks: Task[]): number {
   return tasks.some(t => t.status === "in_progress") ? ACTIVE_REMINDER_INTERVAL : REMINDER_INTERVAL;
 }
 
-/** How many turns completed tasks linger before auto-clearing. */
+/** How many turns individually completed tasks linger in on_task_complete mode. */
 const AUTO_CLEAR_DELAY = 4;
 
 /** Neutralize a task field for the echo: collapse newlines and strip reminder tags. */
@@ -327,7 +327,6 @@ export default function (pi: ExtensionAPI) {
     } else {
       // Actual error — revert to pending
       store.update(task.id, { status: "pending", metadata: { ...task.metadata, lastError: error || status } });
-      autoClear.resetBatchCountdown();
     }
     widget.setActiveTask(task.id, false);
     widget.update();
@@ -350,18 +349,20 @@ export default function (pi: ExtensionAPI) {
     storeUpgraded = true;
   }
 
-  /** Restore widget on session start/resume if there's unfinished work.
-   *  On new sessions, auto-clear if all tasks are completed (clean slate).
-   *  On resume, always show tasks (user may want to review).
-   *  Only runs once — the first caller wins. */
+  /** Restore the widget on session start/resume if there's unfinished work.
+   *  In on_list_complete mode, an all-completed persisted list is stale and
+   *  is cleared even on resume/reload. Other modes retain the old review
+   *  behavior on resume. Only runs once — the first caller wins. */
   function showPersistedTasks(isResume = false) {
     if (persistedTasksShown) return;
     persistedTasksShown = true;
     const tasks = store.list();
     if (tasks.length > 0) {
-      if (!isResume && tasks.every(t => t.status === "completed")) {
+      const allCompleted = tasks.every(t => t.status === "completed");
+      const immediateListCleanup = (cfg.autoClearCompleted ?? "on_list_complete") === "on_list_complete";
+      if (allCompleted && (!isResume || immediateListCleanup)) {
         store.clearCompleted();
-        if (taskScope === "session") store.deleteFileIfEmpty();
+        if (taskScope === "session" && !piTasks) store.deleteFileIfEmpty();
       } else {
         widget.update();
       }
@@ -580,7 +581,6 @@ All tasks are created with status \`pending\`.
     }),
 
     execute(_toolCallId, params, _signal, _onUpdate, _ctx) {
-      autoClear.resetBatchCountdown();
       const meta = params.metadata ?? {};
       if (params.agentType) meta.agentType = params.agentType;
       const task = store.create(params.subject, params.description, params.activeForm, Object.keys(meta).length > 0 ? meta : undefined);
@@ -838,9 +838,6 @@ Set up task dependencies:
       // Update widget active task tracking
       if (fields.status === "in_progress") {
         widget.setActiveTask(taskId);
-        autoClear.resetBatchCountdown();
-      } else if (fields.status === "pending") {
-        autoClear.resetBatchCountdown();
       } else if (fields.status === "completed" || fields.status === "deleted") {
         widget.setActiveTask(taskId, false);
         if (fields.status === "completed") autoClear.trackCompletion(taskId, cadence.currentTurn);

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -90,9 +90,9 @@ export async function openSettingsMenu(
         label: "Auto-clear completed tasks",
         description:
           "never: completed tasks stay visible until manually cleared. " +
-          "on_list_complete: cleared automatically after all tasks are done. " +
-          "on_task_complete: each task cleared shortly after it completes. " +
-          `Clearing lags ~${clearDelayTurns} turns.`,
+          "on_list_complete: the whole list clears immediately when the final task completes. " +
+          "on_task_complete: each task clears individually " +
+          `after ~${clearDelayTurns} turns.`,
         currentValue: cfg.autoClearCompleted ?? "on_list_complete",
         values: ["never", "on_list_complete", "on_task_complete"],
       },

--- a/test/auto-clear.test.ts
+++ b/test/auto-clear.test.ts
@@ -114,70 +114,24 @@ describe("auto-clear: on_list_complete mode", () => {
     expect(store.list()).toHaveLength(2);
   });
 
-  it("does not clear immediately when all tasks complete", () => {
+  it("clears the whole list immediately when the final task completes", () => {
     store.create("A", "Desc");
     store.create("B", "Desc");
     store.update("1", { status: "completed" });
-    store.update("2", { status: "completed" });
-    manager.trackCompletion("2", 1);
-
-    // Turns 2-4: not enough
-    for (let turn = 2; turn <= 4; turn++) {
-      manager.onTurnStart(turn);
-    }
+    manager.trackCompletion("1", 1);
     expect(store.list()).toHaveLength(2);
-  });
 
-  it("clears all completed tasks after REMINDER_INTERVAL turns when all are completed", () => {
-    store.create("A", "Desc");
-    store.create("B", "Desc");
-    store.update("1", { status: "completed" });
     store.update("2", { status: "completed" });
-    manager.trackCompletion("2", 1);
+    manager.trackCompletion("2", 2);
 
-    manager.onTurnStart(5);
     expect(store.list()).toHaveLength(0);
   });
 
-  it("resets countdown when a new task is created before REMINDER_INTERVAL", () => {
-    store.create("A", "Desc");
-    store.update("1", { status: "completed" });
-    manager.trackCompletion("1", 1);
+  it("does not create or clear anything for an empty list", () => {
+    manager.trackCompletion("missing", 1);
 
-    // Turn 3: new task created — reset countdown
-    manager.onTurnStart(3);
-    manager.resetBatchCountdown();
-    store.create("B", "Desc");
-
-    // Turn 5 would have cleared, but countdown was reset at turn 3
-    manager.onTurnStart(5);
-    expect(store.get("1")).toBeDefined(); // still around — list isn't all completed
-  });
-
-  it("resets countdown when a task goes back to in_progress", () => {
-    store.create("A", "Desc");
-    store.create("B", "Desc");
-    store.update("1", { status: "completed" });
-    store.update("2", { status: "completed" });
-    manager.trackCompletion("2", 1);
-
-    // Turn 3: task 2 goes back to in_progress
-    manager.onTurnStart(3);
-    store.update("2", { status: "in_progress" });
-    manager.resetBatchCountdown();
-
-    // Turn 5: would have cleared, but countdown was reset
-    manager.onTurnStart(5);
-    expect(store.list()).toHaveLength(2); // both still here
-  });
-
-  it("returns true when tasks are cleared", () => {
-    store.create("Task", "Desc");
-    store.update("1", { status: "completed" });
-    manager.trackCompletion("1", 1);
-
-    expect(manager.onTurnStart(4)).toBe(false);
-    expect(manager.onTurnStart(5)).toBe(true);
+    expect(store.list()).toHaveLength(0);
+    expect(manager.onTurnStart(10)).toBe(false);
   });
 });
 
@@ -284,22 +238,6 @@ describe("auto-clear: reset (new session)", () => {
     manager.reset();
 
     // Old completion should NOT trigger after reset
-    manager.onTurnStart(5);
-    expect(store.get("1")).toBeDefined();
-  });
-
-  it("reset clears batch countdown so old all-completed state doesn't fire", () => {
-    const store = new TaskStore();
-    const manager = new AutoClearManager(() => store, () => "on_list_complete");
-
-    store.create("Task", "Desc");
-    store.update("1", { status: "completed" });
-    manager.trackCompletion("1", 1);
-
-    // Simulate /new — reset before the delay expires
-    manager.reset();
-
-    // Old batch countdown should NOT trigger after reset
     manager.onTurnStart(5);
     expect(store.get("1")).toBeDefined();
   });

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -3,7 +3,7 @@
  * auto-cascade, and widget agent ID display.
  */
 
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -152,6 +152,30 @@ describe("Session task rehydration", () => {
       expect(ctx.ui.setWidget).toHaveBeenCalledWith("tasks", expect.any(Function), {
         placement: "aboveEditor",
       });
+    } finally {
+      rmSync(taskFile, { force: true });
+    }
+  });
+
+  it("clears an all-completed list after /resume in on_list_complete mode", async () => {
+    const sessionId = `resume-completed-${process.pid}-${Date.now()}`;
+    const taskFile = join(process.cwd(), ".pi", "tasks", `tasks-${sessionId}.json`);
+    try {
+      const persisted = new TaskStore(taskFile);
+      persisted.create("Already done", "Should not be restored");
+      persisted.update("1", { status: "completed" });
+      delete process.env.PI_TASKS;
+      const mock = mockPi();
+      initExtension(mock.pi as any);
+      const ctx = {
+        ...mockCtx(),
+        sessionManager: { getSessionId: vi.fn(() => sessionId) },
+      };
+
+      await mock.fireLifecycle("session_start", { reason: "resume" }, ctx);
+
+      expect(new TaskStore(taskFile).list()).toHaveLength(0);
+      expect(existsSync(taskFile)).toBe(false);
     } finally {
       rmSync(taskFile, { force: true });
     }
@@ -465,6 +489,10 @@ describe("Completion listener", () => {
       description: "Desc",
       agentType: "general-purpose",
     });
+    await mock.executeTool("TaskCreate", {
+      subject: "Remaining task",
+      description: "Keeps the list open so the completed task can be inspected",
+    });
     await mock.executeTool("TaskExecute", { task_ids: ["1"] });
 
     // Simulate agent completion
@@ -472,6 +500,20 @@ describe("Completion listener", () => {
 
     const result = await mock.executeTool("TaskGet", { taskId: "1" });
     expect(result.content[0].text).toContain("Status: completed");
+  });
+
+  it("clears the tracker when the final agent task completes", async () => {
+    await mock.executeTool("TaskCreate", {
+      subject: "Final agent task",
+      description: "Desc",
+      agentType: "general-purpose",
+    });
+    await mock.executeTool("TaskExecute", { task_ids: ["1"] });
+
+    mock.emitEvent("subagents:completed", { id: "agent-1" });
+
+    const result = await mock.executeTool("TaskList", {});
+    expect(result.content[0].text).toBe("No tasks found");
   });
 
   it("reverts task to pending on subagents:failed event", async () => {
@@ -634,6 +676,15 @@ describe("Standalone operation (no subagents extension)", () => {
     await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
     const result = await mock.executeTool("TaskGet", { taskId: "1" });
     expect(result.content[0].text).toContain("in_progress");
+  });
+
+  it("clears the tracker when TaskUpdate completes the final task", async () => {
+    await mock.executeTool("TaskCreate", { subject: "Finish me", description: "desc" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "completed" });
+
+    const result = await mock.executeTool("TaskList", {});
+    expect(result.content[0].text).toBe("No tasks found");
   });
 
   it("TaskExecute gracefully refuses without subagents", async () => {


### PR DESCRIPTION
## Problem

The default `on_list_complete` mode starts a four-turn countdown after the final task completes. Starting another batch before that countdown expires resets it, so completed batches can remain in the tracker indefinitely and accumulate behind newer work.

## Changes

- clear the whole tracker synchronously when the final task becomes `completed` in `on_list_complete` mode
- keep partial lists intact while any task is `pending` or `in_progress`
- preserve the delayed behavior of `on_task_complete` and the retention behavior of `never`
- treat all-completed persisted lists as stale on resume/reload when `on_list_complete` is active
- update settings copy, README, and changelog to document the lifecycle
- cover direct `TaskUpdate`, subagent completion, partial lists, empty lists, and session resume

This intentionally removes the short all-done linger only from `on_list_complete`; users who want completed rows to remain briefly can still select `on_task_complete`.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 190 passed
- `npm run build`
