### PR TITLE
fix: resume unfinished tasks after user questions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ function buildSystemReminder(tasks: Task[]): string {
     "<system-reminder>",
     header,
     "",
-    `${JSON.stringify(items)}.${overflow} Continue on with the tasks at hand if applicable.`,
+    `${JSON.stringify(items)}.${overflow} Answer the user's latest message first if it needs a response. Then continue working through the unfinished tasks in this same run. Do not stop merely because the user's question has been answered.`,
     "</system-reminder>",
   ].join("\n");
 }
@@ -377,6 +377,36 @@ export default function (pi: ExtensionAPI) {
     taskToolNames: TASK_TOOL_NAMES,
   };
 
+  // A user may steer the agent with a question while it is executing a task
+  // list. Once that question is answered, Pi would normally settle and wait
+  // for more input. Remember the interruption so agent_settled can enqueue one
+  // continuation turn when unfinished tasks still exist.
+  let continueAfterUserMessage = false;
+
+  function explicitlyPausesTaskWork(text: string): boolean {
+    const normalized = text.trim().toLowerCase();
+    return /^(?:please[\s,:-]+)?(?:stop|pause|cancel|halt|wait)(?:\s|[.!?,]|$)/.test(normalized)
+      || /^(?:пожалуйста[\s,:-]+)?(?:остановись|останови|пауза|отмени|не продолжай|подожди|хватит)(?:\s|[.!?,]|$)/.test(normalized);
+  }
+
+  pi.on("input", async (event, ctx) => {
+    if (event.source === "extension") return { action: "continue" as const };
+
+    upgradeStoreIfNeeded(ctx);
+    const hasUnfinishedTasks = store.list().some(task => task.status !== "completed");
+    if (!hasUnfinishedTasks || explicitlyPausesTaskWork(event.text)) {
+      continueAfterUserMessage = false;
+      return { action: "continue" as const };
+    }
+
+    continueAfterUserMessage = true;
+    // Make the current response aware of the unfinished list immediately,
+    // rather than waiting for the normal multi-turn reminder cadence.
+    cadence.reminderDue = true;
+    cadence.reminderInjectedThisCycle = false;
+    return { action: "continue" as const };
+  });
+
   pi.on("turn_start", async (_event, ctx) => {
     onTurnStart(cadence);
     latestCtx = ctx;
@@ -461,6 +491,25 @@ export default function (pi: ExtensionAPI) {
     };
   });
 
+  pi.on("agent_settled", async (_event, ctx) => {
+    if (!continueAfterUserMessage || !ctx.isIdle()) return;
+
+    const unfinishedCount = store.list().filter(task => task.status !== "completed").length;
+    continueAfterUserMessage = false;
+    if (unfinishedCount === 0) return;
+
+    pi.sendMessage({
+      customType: "task-continuation",
+      content: [
+        "<system-reminder>",
+        `The user's latest message has been answered, but ${unfinishedCount} task${unfinishedCount === 1 ? " remains" : "s remain"} unfinished.`,
+        "Resume the task list now. Use TaskList to select the next actionable task, keep task statuses current, and continue until the remaining work is complete or genuinely blocked. Do not merely report that tasks remain.",
+        "</system-reminder>",
+      ].join("\n"),
+      display: false,
+    }, { deliverAs: "followUp", triggerTurn: true });
+  });
+
   // session_start replaces the never-emitted session_switch event. Rehydrating
   // here matters because before_agent_start only fires once the user prompts.
   pi.on("session_start", async (event, ctx) => {
@@ -478,6 +527,7 @@ export default function (pi: ExtensionAPI) {
     if (isSwitch) {
       storeUpgraded = false;
       persistedTasksShown = false;
+      continueAfterUserMessage = false;
       resetCadenceState(cadence);
       autoClear.reset();
       // Memory mode has no file to switch — clear tasks explicitly on /new.

--- a/test/stale-task-reminder.test.ts
+++ b/test/stale-task-reminder.test.ts
@@ -93,7 +93,8 @@ describe("stale in_progress task reminders", () => {
     expect(reminder).toContain("latest contents of your task list");
     expect(reminder).toContain('"content":"Finish stale reminder test"');
     expect(reminder).toContain('"status":"in_progress"');
-    expect(reminder).toContain("Continue on with the tasks at hand");
+    expect(reminder).toContain("continue working through the unfinished tasks in this same run");
+    expect(reminder).toContain("Do not stop merely because the user's question has been answered");
 
     unping();
   });

--- a/test/task-continuation.test.ts
+++ b/test/task-continuation.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import initExtension from "../src/index.js";
+
+beforeEach(() => { process.env.PI_TASKS = "off"; });
+afterEach(() => { delete process.env.PI_TASKS; });
+
+function mockCtx(idle = true) {
+  return {
+    model: { id: "test-model", name: "Test" },
+    modelRegistry: {},
+    isIdle: vi.fn(() => idle),
+    ui: {
+      setWidget: vi.fn(),
+      setStatus: vi.fn(),
+      notify: vi.fn(),
+    },
+  };
+}
+
+function mockPi() {
+  const tools = new Map<string, any>();
+  const eventHandlers = new Map<string, ((data: unknown) => void)[]>();
+  const lifecycleHandlers = new Map<string, ((...args: any[]) => any)[]>();
+
+  const pi = {
+    registerTool(def: any) { tools.set(def.name, def); },
+    registerCommand: vi.fn(),
+    sendMessage: vi.fn(),
+    on(event: string, handler: any) {
+      if (!lifecycleHandlers.has(event)) lifecycleHandlers.set(event, []);
+      lifecycleHandlers.get(event)!.push(handler);
+    },
+    events: {
+      emit(channel: string, data: unknown) {
+        for (const handler of eventHandlers.get(channel) ?? []) handler(data);
+      },
+      on(channel: string, handler: (data: unknown) => void) {
+        if (!eventHandlers.has(channel)) eventHandlers.set(channel, []);
+        eventHandlers.get(channel)!.push(handler);
+        return () => {
+          const handlers = eventHandlers.get(channel);
+          if (handlers) eventHandlers.set(channel, handlers.filter(item => item !== handler));
+        };
+      },
+    },
+  };
+
+  return {
+    pi,
+    async executeTool(name: string, params: any) {
+      const tool = tools.get(name);
+      if (!tool) throw new Error(`Tool ${name} not registered`);
+      return tool.execute("call-1", params, undefined, undefined, mockCtx());
+    },
+    async fireLifecycle(event: string, ...args: any[]) {
+      let lastResult: any;
+      for (const handler of lifecycleHandlers.get(event) ?? []) {
+        const result = await handler(...args);
+        if (result !== undefined) lastResult = result;
+      }
+      return lastResult;
+    },
+  };
+}
+
+function installPingResponder(pi: ReturnType<typeof mockPi>["pi"]) {
+  return pi.events.on("subagents:rpc:ping", (data: unknown) => {
+    const { requestId } = data as { requestId: string };
+    pi.events.emit(`subagents:rpc:ping:reply:${requestId}`, {
+      success: true,
+      data: { version: 2 },
+    });
+  });
+}
+
+describe("continuing tasks after a user message", () => {
+  it("injects the unfinished list immediately and resumes once after the answer", async () => {
+    const mock = mockPi();
+    const unping = installPingResponder(mock.pi);
+    initExtension(mock.pi as any);
+
+    await mock.executeTool("TaskCreate", { subject: "Finish implementation", description: "Desc" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
+
+    const inputResult = await mock.fireLifecycle("input", {
+      text: "Why is this taking so long?",
+      source: "interactive",
+      streamingBehavior: "steer",
+    }, mockCtx(false));
+    expect(inputResult).toEqual({ action: "continue" });
+
+    const contextResult = await mock.fireLifecycle("context", { messages: [] });
+    const reminder = contextResult.messages.at(-1).content[0].text;
+    expect(reminder).toContain('"content":"Finish implementation"');
+    expect(reminder).toContain("Answer the user's latest message first");
+    expect(reminder).toContain("continue working through the unfinished tasks in this same run");
+
+    await mock.fireLifecycle("agent_settled", {}, mockCtx(true));
+    expect(mock.pi.sendMessage).toHaveBeenCalledOnce();
+    expect(mock.pi.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customType: "task-continuation",
+        content: expect.stringContaining("Resume the task list now"),
+        display: false,
+      }),
+      { deliverAs: "followUp", triggerTurn: true },
+    );
+
+    // The continuation is one-shot, so an uncooperative model cannot create an
+    // infinite settle/resume loop without another real user message.
+    await mock.fireLifecycle("agent_settled", {}, mockCtx(true));
+    expect(mock.pi.sendMessage).toHaveBeenCalledOnce();
+
+    unping();
+  });
+
+  it("does not resume when the user explicitly pauses the work", async () => {
+    const mock = mockPi();
+    const unping = installPingResponder(mock.pi);
+    initExtension(mock.pi as any);
+
+    await mock.executeTool("TaskCreate", { subject: "Keep working", description: "Desc" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
+
+    await mock.fireLifecycle("input", {
+      text: "Остановись, пожалуйста",
+      source: "interactive",
+      streamingBehavior: "steer",
+    }, mockCtx(false));
+    expect(await mock.fireLifecycle("context", { messages: [] })).toEqual({});
+
+    await mock.fireLifecycle("agent_settled", {}, mockCtx(true));
+    expect(mock.pi.sendMessage).not.toHaveBeenCalled();
+
+    unping();
+  });
+
+  it("does not resume when all tasks were completed while answering", async () => {
+    const mock = mockPi();
+    const unping = installPingResponder(mock.pi);
+    initExtension(mock.pi as any);
+
+    await mock.executeTool("TaskCreate", { subject: "Answer and finish", description: "Desc" });
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "in_progress" });
+    await mock.fireLifecycle("input", {
+      text: "What is the current status?",
+      source: "interactive",
+    }, mockCtx());
+
+    await mock.executeTool("TaskUpdate", { taskId: "1", status: "completed" });
+    await mock.fireLifecycle("agent_settled", {}, mockCtx(true));
+
+    expect(mock.pi.sendMessage).not.toHaveBeenCalled();
+    unping();
+  });
+
+  it("waits for a genuinely idle settle event before queuing continuation", async () => {
+    const mock = mockPi();
+    const unping = installPingResponder(mock.pi);
+    initExtension(mock.pi as any);
+
+    await mock.executeTool("TaskCreate", { subject: "Resume later", description: "Desc" });
+    await mock.fireLifecycle("input", {
+      text: "Quick question",
+      source: "interactive",
+      streamingBehavior: "followUp",
+    }, mockCtx(false));
+
+    await mock.fireLifecycle("agent_settled", {}, mockCtx(false));
+    expect(mock.pi.sendMessage).not.toHaveBeenCalled();
+
+    await mock.fireLifecycle("agent_settled", {}, mockCtx(true));
+    expect(mock.pi.sendMessage).toHaveBeenCalledOnce();
+    unping();
+  });
+});


### PR DESCRIPTION
## Summary

- inject unfinished-task context immediately when a user message arrives during an open task list
- enqueue one follow-up continuation after the answer if tasks remain
- respect explicit pause/cancel requests and avoid infinite continuation loops

## Validation

- `npm test` (195 tests)
- `npm run typecheck`
- `npm run lint`
- `npm run build`