### PR TITLE
feat: support custom task sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,28 @@ The extension renders a persistent widget above the editor:
 
 ### Widget display settings
 
-How tasks are sorted and how many are shown can be configured via `/tasks` → Settings (saved as project overrides in `.pi/tasks-config.json`). All defaults preserve the original behaviour.
+Task display can be configured via `/tasks` → Settings (saved as project overrides in `.pi/tasks-config.json`). Defaults preserve the existing ID-ordered, expanded task list.
 
 | Setting | Values | Default | Behaviour |
 |---------|--------|---------|-----------|
-| `sortOrder` | `id` / `status` / `recent` / `oldest` | `id` | `id` = creation order; `status` groups completed → in-progress → pending; `recent`/`oldest` = by last-updated time |
-| `maxVisible` | `5`–`100` | `10` | Caps how many task lines the widget shows (ignored when `showAll` is on) |
-| `showAll` | `true` / `false` | `false` | When `true`, every task is shown regardless of `maxVisible` |
-| `hiddenAt` | `bottom` / `top` | `bottom` | When the list overflows `maxVisible`, where the `… and N more` collapse happens. `top` pairs well with `sortOrder: status` to keep active work visible and fold completed tasks away |
+| `collapseCompleted` | `true` / `false` | `false` | When enabled, collapses completed tasks to one count line and always shows every in-progress and pending task |
+| `sortOrder` | `id` / `status` / `recent` / `oldest` | `id` | `status` groups completed → in-progress → pending; `id` = creation order; `recent`/`oldest` = by last-updated time |
+| `maxVisible` | `5`–`100` | `10` | In expanded mode, caps task lines when `showAll` is off |
+| `showAll` | `true` / `false` | `false` | In expanded mode, shows every task regardless of `maxVisible` |
+| `hiddenAt` | `bottom` / `top` | `bottom` | In expanded mode, controls where the `… and N more` truncation occurs |
 
-> Note: the widget's `status` order is completed-first (so finished work collapses at the top with `hiddenAt: top`), which is the reverse of the `TaskList` tool's pending-first order.
+For custom ordering, an executable `tasks-config.cjs` can provide a comparator. Global configuration lives in the agent directory; project configuration lives at `.pi/tasks-config.cjs`:
+
+```js
+module.exports = {
+  sortOrder: (a, b) => {
+    const rank = { in_progress: 0, pending: 1, completed: 2 };
+    return rank[a.status] - rank[b.status] || Number(a.id) - Number(b.id);
+  },
+};
+```
+
+Executable configuration overrides JSON configuration at the same scope. Project configuration overrides global configuration.
 
 ## Tools
 
@@ -215,7 +227,7 @@ The `autoClearCompleted` setting controls automatic cleanup of completed tasks:
 
 Both auto-clear modes use a turn-based delay for non-jarring UX — tasks linger briefly so you see the completion before they disappear.
 
-Settings (`taskScope`, `autoCascade`, `autoClearCompleted`, plus the [widget display settings](#widget-display-settings) `sortOrder` / `maxVisible` / `showAll` / `hiddenAt`) changed through `/tasks` are saved as project overrides in `<cwd>/.pi/tasks-config.json`.
+Settings (`taskScope`, `autoCascade`, `autoClearCompleted`, plus the [widget display settings](#widget-display-settings) `collapseCompleted` / `sortOrder` / `maxVisible` / `showAll` / `hiddenAt`) changed through `/tasks` are saved as project overrides in `<cwd>/.pi/tasks-config.json`.
 
 ### Global defaults
 

--- a/src/task-store.ts
+++ b/src/task-store.ts
@@ -8,7 +8,7 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join } from "node:path";
-import type { Task, TaskStatus, TaskStoreData } from "./types.js";
+import type { Task, TaskSortOrder, TaskStatus, TaskStoreData } from "./types.js";
 
 function sortById(a: Task, b: Task): number {
   return Number(a.id) - Number(b.id);
@@ -177,9 +177,10 @@ export class TaskStore {
   }
 
   /** List all tasks, sorted by the given order (defaults to ID ascending). */
-  list(sortOrder: "id" | "status" | "recent" | "oldest" = "id"): Task[] {
+  list(sortOrder: TaskSortOrder = "id"): Task[] {
     if (this.filePath) this.load();
-    return Array.from(this.tasks.values()).sort(SORT_FNS[sortOrder]);
+    const compare = typeof sortOrder === "function" ? sortOrder : SORT_FNS[sortOrder];
+    return Array.from(this.tasks.values()).sort(compare);
   }
 
   update(id: string, fields: {

--- a/src/tasks-config.ts
+++ b/src/tasks-config.ts
@@ -1,24 +1,42 @@
 // <agent-dir>/tasks-config.json provides global defaults.
 // <cwd>/.pi/tasks-config.json provides project overrides.
 
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { TaskSortOrder } from "./types.js";
+
+const require = createRequire(import.meta.url);
 
 export interface TasksConfig {
   taskScope?: "memory" | "session" | "project";  // default: "session"
   autoCascade?: boolean;   // default: false
   autoClearCompleted?: "never" | "on_list_complete" | "on_task_complete";  // default: "on_list_complete"
-  showAll?: boolean;                     // default: false
-  maxVisible?: number;                   // default: 10
-  sortOrder?: "id" | "status" | "recent" | "oldest";  // default: "id"
+  collapseCompleted?: boolean;           // default: false
+  showAll?: boolean;                     // default: false (expanded mode only)
+  maxVisible?: number;                   // default: 10 (expanded mode only)
+  sortOrder?: TaskSortOrder;              // default: "id"
   hiddenAt?: "top" | "bottom";                         // default: "bottom"
+}
+
+function asTasksConfig(parsed: unknown): TasksConfig {
+  return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as TasksConfig : {};
 }
 
 function readTasksConfig(configPath: string): TasksConfig {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(configPath, "utf-8"));
-    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as TasksConfig : {};
+    return asTasksConfig(JSON.parse(readFileSync(configPath, "utf-8")));
+  } catch {
+    return {};
+  }
+}
+
+function readExecutableTasksConfig(configPath: string): TasksConfig {
+  if (!existsSync(configPath)) return {};
+  try {
+    const loaded = require(configPath) as unknown;
+    return asTasksConfig((loaded as { default?: unknown })?.default ?? loaded);
   } catch {
     return {};
   }
@@ -26,14 +44,21 @@ function readTasksConfig(configPath: string): TasksConfig {
 
 export function loadTasksConfig(cwd = process.cwd(), agentDir = getAgentDir()): TasksConfig {
   const globalConfig = readTasksConfig(join(agentDir, "tasks-config.json"));
+  const globalExecutableConfig = readExecutableTasksConfig(join(agentDir, "tasks-config.cjs"));
   const projectConfig = readTasksConfig(join(cwd, ".pi", "tasks-config.json"));
-  return { ...globalConfig, ...projectConfig };
+  const projectExecutableConfig = readExecutableTasksConfig(join(cwd, ".pi", "tasks-config.cjs"));
+  return { ...globalConfig, ...globalExecutableConfig, ...projectConfig, ...projectExecutableConfig };
 }
 
 export function saveTasksConfig(config: TasksConfig, cwd = process.cwd(), agentDir = getAgentDir()): void {
   const configPath = join(cwd, ".pi", "tasks-config.json");
-  const globalConfig = readTasksConfig(join(agentDir, "tasks-config.json"));
-  const projectOverrides = Object.fromEntries(Object.entries(config).filter(([key, value]) => globalConfig[key as keyof TasksConfig] !== value));
+  const globalConfig = {
+    ...readTasksConfig(join(agentDir, "tasks-config.json")),
+    ...readExecutableTasksConfig(join(agentDir, "tasks-config.cjs")),
+  };
+  const projectOverrides = Object.fromEntries(Object.entries(config).filter(([key, value]) =>
+    typeof value !== "function" && globalConfig[key as keyof TasksConfig] !== value
+  ));
   mkdirSync(dirname(configPath), { recursive: true });
   writeFileSync(configPath, JSON.stringify(projectOverrides, null, 2));
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,9 @@
  */
 
 export type TaskStatus = "pending" | "in_progress" | "completed";
+export type BuiltInTaskSortOrder = "id" | "status" | "recent" | "oldest";
+export type TaskComparator = (a: Task, b: Task) => number;
+export type TaskSortOrder = BuiltInTaskSortOrder | TaskComparator;
 
 export interface Task {
   id: string;

--- a/src/ui/settings-menu.ts
+++ b/src/ui/settings-menu.ts
@@ -50,11 +50,20 @@ export async function openSettingsMenu(
         values: ["on", "off"],
       },
       {
+        id: "collapseCompleted",
+        label: "Collapse completed tasks",
+        description:
+          "When ON, every in-progress and open task is shown and completed tasks become one count line. " +
+          "When OFF, completed tasks are listed individually and the visible limit applies.",
+        currentValue: (cfg.collapseCompleted ?? false) ? "on" : "off",
+        values: ["on", "off"],
+      },
+      {
         id: "showAll",
         label: "Show all tasks in widget",
         description:
-          "When ON, every task is shown regardless of the visible limit. " +
-          "When OFF, the list is capped by 'Max visible tasks'.",
+          "In expanded-completed mode, show every task regardless of the visible limit. " +
+          "Collapsed mode always shows every active task.",
         currentValue: (cfg.showAll ?? false) ? "on" : "off",
         values: ["on", "off"],
       },
@@ -62,7 +71,7 @@ export async function openSettingsMenu(
         id: "maxVisible",
         label: "Max visible tasks in widget",
         description:
-          "Only applies when 'Show all tasks' is OFF. " +
+          "Only applies when completed tasks are expanded and 'Show all tasks' is OFF. " +
           "Caps how many task lines the widget shows.",
         currentValue: String(cfg.maxVisible ?? 10),
         values: ["5", "10", "15", "20", "30", "50", "100"],
@@ -71,10 +80,12 @@ export async function openSettingsMenu(
         id: "sortOrder",
         label: "Widget sort order",
         description:
-          '"status" groups by completed → in-progress → pending. ' +
+          '"status" groups by in-progress → open → completed. ' +
           '"id" sorts by creation order.',
-        currentValue: cfg.sortOrder ?? "id",
-        values: ["id", "status", "recent", "oldest"],
+        currentValue: typeof cfg.sortOrder === "function" ? "custom" : (cfg.sortOrder ?? "id"),
+        values: typeof cfg.sortOrder === "function"
+          ? ["custom", "id", "status", "recent", "oldest"]
+          : ["id", "status", "recent", "oldest"],
       },
       {
         id: "hiddenAt",
@@ -115,6 +126,10 @@ export async function openSettingsMenu(
           cfg.autoClearCompleted = newValue as TasksConfig["autoClearCompleted"];
           saveTasksConfig(cfg);
         }
+        if (id === "collapseCompleted") {
+          cfg.collapseCompleted = newValue === "on";
+          saveTasksConfig(cfg);
+        }
         if (id === "showAll") {
           cfg.showAll = newValue === "on";
           saveTasksConfig(cfg);
@@ -123,7 +138,7 @@ export async function openSettingsMenu(
           cfg.maxVisible = Number(newValue);
           saveTasksConfig(cfg);
         }
-        if (id === "sortOrder") {
+        if (id === "sortOrder" && newValue !== "custom") {
           cfg.sortOrder = newValue as TasksConfig["sortOrder"];
           saveTasksConfig(cfg);
         }

--- a/src/ui/task-widget.ts
+++ b/src/ui/task-widget.ts
@@ -167,12 +167,16 @@ export class TaskWidget {
     const spinnerChar = SPINNER[this.widgetFrame % SPINNER.length];
     const lines: string[] = [truncate(theme.fg("accent", "●") + " " + theme.fg("accent", statusText))];
 
+    const collapseCompleted = this.config.collapseCompleted ?? false;
+    const displayTasks = collapseCompleted ? tasks.filter(task => task.status !== "completed") : tasks;
     const showAll = this.config.showAll ?? false;
     const limit = this.config.maxVisible ?? DEFAULT_MAX_VISIBLE_TASKS;
     const hiddenAt = this.config.hiddenAt ?? "bottom";
-    const visible = showAll ? tasks : TRUNCATE_FNS[hiddenAt](tasks, limit);
+    // Collapsed mode always keeps every actionable task visible. Expanded mode
+    // retains the configurable legacy truncation behavior.
+    const visible = collapseCompleted || showAll ? displayTasks : TRUNCATE_FNS[hiddenAt](displayTasks, limit);
 
-    const hiddenCount = tasks.length - visible.length;
+    const hiddenCount = displayTasks.length - visible.length;
     const overflowLine = hiddenCount > 0
       ? truncate(theme.fg("dim", `    … and ${hiddenCount} more`))
       : undefined;
@@ -237,6 +241,10 @@ export class TaskWidget {
 
     if (overflowLine && hiddenAt !== "top") {
       lines.push(overflowLine);
+    }
+    if (collapseCompleted && completed.length > 0) {
+      const label = completed.length === 1 ? "completed task" : "completed tasks";
+      lines.push(truncate(`  ${theme.fg("success", "✔")} ${theme.fg("dim", `${completed.length} ${label}`)}`));
     }
 
     return lines;

--- a/test/custom-sort.test.ts
+++ b/test/custom-sort.test.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { TaskStore } from "../src/task-store.js";
+import { loadTasksConfig } from "../src/tasks-config.js";
+import type { TaskComparator } from "../src/types.js";
+import { TaskWidget, type Theme, type UICtx } from "../src/ui/task-widget.js";
+
+const temporaryDirectories: string[] = [];
+
+function activeFirstComparator(): TaskComparator {
+  return (a, b) => {
+    const rank = { in_progress: 0, pending: 1, completed: 2 };
+    return rank[a.status] - rank[b.status] || Number(a.id) - Number(b.id);
+  };
+}
+
+function render(store: TaskStore): string[] {
+  let content: Parameters<UICtx["setWidget"]>[1];
+  const ui: UICtx = {
+    setStatus() {},
+    setWidget(_key, value) { content = value; },
+  };
+  const widget = new TaskWidget(store, { collapseCompleted: true, sortOrder: activeFirstComparator() });
+  widget.setUICtx(ui);
+  widget.update();
+  const theme: Theme = {
+    fg: (_color, text) => text,
+    bold: text => text,
+    strikethrough: text => text,
+  };
+  const component = content!({ terminal: { columns: 200 }, requestRender() {} }, theme);
+  const lines = component.render();
+  widget.dispose();
+  return lines;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+describe("custom task sorting", () => {
+  it("accepts a comparator without changing built-in status ordering", () => {
+    const store = new TaskStore();
+    store.create("Pending", "");
+    store.create("Completed", "");
+    store.create("In progress", "");
+    store.update("2", { status: "completed" });
+    store.update("3", { status: "in_progress" });
+
+    expect(store.list("status").map(task => task.subject)).toEqual(["Completed", "In progress", "Pending"]);
+    expect(store.list(activeFirstComparator()).map(task => task.subject)).toEqual(["In progress", "Pending", "Completed"]);
+  });
+
+  it("loads a comparator from tasks-config.cjs", () => {
+    const root = mkdtempSync(join(tmpdir(), "pi-tasks-custom-sort-"));
+    temporaryDirectories.push(root);
+    const agentDir = join(root, "agent");
+    const cwd = join(root, "project");
+    mkdirSync(agentDir, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(agentDir, "tasks-config.json"), JSON.stringify({ collapseCompleted: true }));
+    writeFileSync(join(agentDir, "tasks-config.cjs"), `module.exports = {
+      sortOrder: (a, b) => ({ in_progress: 0, pending: 1, completed: 2 }[a.status] - { in_progress: 0, pending: 1, completed: 2 }[b.status])
+    };`);
+
+    const config = loadTasksConfig(cwd, agentDir);
+    expect(config.collapseCompleted).toBe(true);
+    expect(typeof config.sortOrder).toBe("function");
+  });
+
+  it("shows all active tasks and one completed count when enabled", () => {
+    const store = new TaskStore();
+    for (let index = 1; index <= 12; index++) store.create(`Open ${index}`, "");
+    store.create("Done 1", "");
+    store.create("Done 2", "");
+    store.create("Working", "");
+    store.update("13", { status: "completed" });
+    store.update("14", { status: "completed" });
+    store.update("15", { status: "in_progress" });
+
+    const lines = render(store);
+    expect(lines[1]).toContain("Working");
+    expect(lines.filter(line => line.includes("Open "))).toHaveLength(12);
+    expect(lines.at(-1)).toContain("2 completed tasks");
+    expect(lines.some(line => line.includes("more"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Allows `sortOrder` to be a comparator function loaded from `tasks-config.cjs`, and adds optional completed-task collapsing.

Existing defaults, built-in sort behavior, and tests are unchanged. Three tests cover the new options.

Tests: lint, typecheck, 194 tests, build.