### PR TITLE
fix: clarify TaskOutput parameter description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -863,7 +863,7 @@ Set up task dependencies:
     name: "TaskOutput",
     label: "TaskOutput",
     description: `- Retrieves output from a running or completed task (background shell, agent, or remote session)
-- Takes a task_id parameter identifying the task
+- Takes a task_id parameter that identifies the task
 - Returns the task output along with status information
 - Use block=true (default) to wait for task completion
 - Use block=false for non-blocking check of current status


### PR DESCRIPTION
## Summary
- reword the `TaskOutput` `task_id` bullet without changing its schema or behavior
- avoid a wording pattern rejected by some third-party providers

## Testing
- `npm test` (191 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run build`