### PR TITLE
docs(TaskCreate): steer parallel TaskCreate calls for multi-task batches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -605,7 +605,7 @@ Use this tool proactively in these scenarios:
 - Non-trivial and complex tasks - Tasks that require careful planning or multiple operations
 - Plan mode - When using plan mode, create a task list to track the work
 - User explicitly requests todo list - When the user directly asks you to use the todo list
-- User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated)
+- User provides multiple tasks - When users provide a list of things to be done (numbered or comma-separated). Create them all in one response with one TaskCreate call per task
 - After receiving new instructions - Immediately capture user requirements as tasks
 - When you start working on a task - Mark it as in_progress BEFORE beginning work
 - After completing a task - Mark it as completed and add any new follow-up tasks discovered during implementation
@@ -634,7 +634,8 @@ All tasks are created with status \`pending\`.
 - Include enough detail in the description for another agent to understand and complete the task
 - After creating tasks, use TaskUpdate to set up dependencies (blocks/blockedBy) if needed
 - Check TaskList first to avoid creating duplicate tasks
-- Include \`agentType\` (e.g., "general-purpose", "Explore") to mark tasks for subagent execution via TaskExecute`,
+- Include \`agentType\` (e.g., "general-purpose", "Explore") to mark tasks for subagent execution via TaskExecute
+- To create several tasks at once, call TaskCreate multiple times in a single response — independent tool calls run in parallel, so the whole batch is created in one turn (one task per call).`,
     promptGuidelines: [
       "When working on complex multi-step tasks, use TaskCreate to track progress and TaskUpdate to update status.",
       "Mark tasks as in_progress before starting work and completed when done.",


### PR DESCRIPTION
## Purpose

Replaces the closed [#24](https://github.com/tintinweb/pi-tasks/pull/24) (batch `TaskCreate` parameter). Instead of adding a batch API, this PR **steers the model through the tool description** to batch-create tasks the way the runtime already supports: by issuing multiple `TaskCreate` calls in a single response.

Pi executes independent tool calls from one assistant message in parallel (default parallel tool execution mode; results restored to the model's original call order). Verified empirically: three parallel bash calls started within ~34ms of each other and ran concurrently; three parallel `TaskCreate` calls created tasks without collisions (sequential IDs, results in call order). So the model can create N tasks in one turn with no extension API change at all.

## Change

Description-only, 3 lines in `TaskCreate`'s tool description (visible to the coding agent):

- **`## When to Use`** — "User provides multiple tasks" bullet now says: *Create them all in one response with one TaskCreate call per task*
- **`## Tips`** — new bullet: *To create several tasks at once, call TaskCreate multiple times in a single response — independent tool calls run in parallel, so the whole batch is created in one turn (one task per call).*

No schema or behavior changes: `subject`/`description` remain required, and the tool stays 1:1 with Claude Code. This also sidesteps the earlier concern about making `subject`/`description` optional to accommodate a batch parameter.

## Verification

- `npm run typecheck` — clean
- `npm test` — 346 passed (16 files)
- `npm run build` — clean

— swift-viper-90 🤖