### PR TITLE
fix(storage): keep session tasks outside workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,14 @@ Task storage is controlled by the `taskScope` setting (`/tasks` → Settings →
 | Mode | File | Behaviour |
 |------|------|-----------|
 | `memory` | *(none)* | In-memory only — tasks lost when session ends |
-| `session` **(default)** | `<workspace>/.pi/tasks/tasks-<sessionId>.json` | Per-session file — isolated between sessions, survives resume |
+| `session` **(default)** | `~/.pi/tasks/sessions/<project-key>/tasks-<sessionId>.json` | Per-session file — isolated between workspaces and sessions, survives resume |
 | `project` | `<workspace>/.pi/tasks/tasks.json` | Shared across all sessions in the project |
 
-`<workspace>` is the directory pi reports for the session — the same one its file tools operate in. That is normally where you started pi; it differs only when a session is opened by an explicit path from another project, or when a host serves sessions from elsewhere.
+`<workspace>` is the directory pi reports for the session — the same one its file tools operate in. That is normally where you started pi; it differs only when a session is opened by an explicit path from another project, or when a host serves sessions from elsewhere. `<project-key>` is a SHA-256 digest of that workspace path, keeping runtime metadata outside the project while preventing same-ID sessions in different workspaces from colliding.
 
 Under `session` scope, tasks stay in memory whenever pi is not persisting the session (`pi --no-session`) — there is no session for the file to belong to, so none is written. `project` scope still writes its shared list, since that belongs to the project rather than the session.
+
+Existing default session files under `<workspace>/.pi/tasks/` migrate lazily when their session is opened. Migration never overwrites a global destination that already exists; in that conflict case the global file is used and the legacy file is left untouched. Successfully migrated files and empty legacy directories are removed.
 
 On new session start, if all persisted tasks are completed they are auto-cleared for a clean slate. On session resume, all tasks (including completed) are shown so the user can review progress. Empty session files are automatically deleted when all tasks are cleared.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import {
   onTurnStart,
   resetCadenceState,
 } from "./reminder-cadence.js";
+import { migrateLegacySessionTaskFile, sessionTaskFile } from "./task-paths.js";
 import { TaskStore } from "./task-store.js";
 import { loadGlobalTasksConfig, loadTasksConfig } from "./tasks-config.js";
 import type { Task } from "./types.js";
@@ -144,7 +145,7 @@ export default function (pi: ExtensionAPI) {
     if (taskScope === "memory") return { key: "memory:config" };
     if (!cwd) return { key: "pending:workspace" };
     if (taskScope === "session" && sessionId) {
-      const path = join(cwd, ".pi", "tasks", `tasks-${sessionId}.json`);
+      const path = sessionTaskFile(cwd, sessionId);
       return { key: `path:${path}`, path };
     }
     if (taskScope === "session") return { key: "pending:session" };
@@ -369,6 +370,9 @@ export default function (pi: ExtensionAPI) {
       : undefined;
     const nextTarget = resolveStoreTarget(ctx.cwd, sessionId);
     if (nextTarget.key !== storeTarget.key) {
+      if (taskScope === "session" && !piTasks && sessionId) {
+        migrateLegacySessionTaskFile(ctx.cwd, sessionId);
+      }
       store = new TaskStore(nextTarget.path);
       widget.setStore(store);
       storeTarget = nextTarget;

--- a/src/task-paths.ts
+++ b/src/task-paths.ts
@@ -1,0 +1,48 @@
+import { createHash, randomUUID } from "node:crypto";
+import { constants, copyFileSync, existsSync, linkSync, mkdirSync, rmdirSync, unlinkSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+/** Global directory for session-scoped task state belonging to one workspace. */
+export function sessionTasksDir(cwd: string): string {
+  const projectKey = createHash("sha256").update(resolve(cwd)).digest("hex");
+  return join(homedir(), ".pi", "tasks", "sessions", projectKey);
+}
+
+/** Default task file for one persisted session in a workspace. */
+export function sessionTaskFile(cwd: string, sessionId: string): string {
+  return join(sessionTasksDir(cwd), `tasks-${sessionId}.json`);
+}
+
+/** Previous default location, retained only as a migration source. */
+export function legacySessionTaskFile(cwd: string, sessionId: string): string {
+  return join(cwd, ".pi", "tasks", `tasks-${sessionId}.json`);
+}
+
+/**
+ * Move one legacy workspace-local session file into global storage. Migration is
+ * lazy, preserves the legacy file when the destination already exists, and never
+ * overwrites global state. Empty legacy directories are removed when possible.
+ */
+export function migrateLegacySessionTaskFile(cwd: string, sessionId: string): void {
+  const source = legacySessionTaskFile(cwd, sessionId);
+  const destination = sessionTaskFile(cwd, sessionId);
+  if (!existsSync(source) || existsSync(destination)) return;
+
+  const temporary = `${destination}.migrate-${process.pid}-${randomUUID()}.tmp`;
+  try {
+    mkdirSync(dirname(destination), { recursive: true });
+    copyFileSync(source, temporary, constants.COPYFILE_EXCL);
+    // Publishing with a hard link is atomic and fails rather than replacing a
+    // destination created by another process during the copy.
+    linkSync(temporary, destination);
+  } catch {
+    return;
+  } finally {
+    try { unlinkSync(temporary); } catch { /* copy was never created */ }
+  }
+
+  try { unlinkSync(source); } catch { return; }
+  try { rmdirSync(dirname(source)); } catch { return; }
+  try { rmdirSync(dirname(dirname(source))); } catch { /* contains other project state */ }
+}

--- a/test/auto-clear-lifecycle.test.ts
+++ b/test/auto-clear-lifecycle.test.ts
@@ -10,6 +10,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import initExtension from "../src/index.js";
+import { sessionTaskFile, sessionTasksDir } from "../src/task-paths.js";
 import { mockPi, mockSessionCtx } from "./helpers/mock-pi.js";
 
 const config = vi.hoisted(() => ({ current: {} as Record<string, unknown> }));
@@ -30,11 +31,12 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.PI_TASKS;
+  rmSync(sessionTasksDir(cwd), { recursive: true, force: true });
   rmSync(cwd, { recursive: true, force: true });
 });
 
 const ctxFor = (sessionId = "s1") => mockSessionCtx(sessionId, { cwd });
-const sessionFile = (sessionId: string) => join(cwd, ".pi", "tasks", `tasks-${sessionId}.json`);
+const sessionFile = (sessionId: string) => sessionTaskFile(cwd, sessionId);
 
 type Mock = ReturnType<typeof mockPi>;
 

--- a/test/store-scope.test.ts
+++ b/test/store-scope.test.ts
@@ -6,11 +6,16 @@
  * .pi/ in the real working directory holds the developer's own task list.
  */
 
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import initExtension from "../src/index.js";
+import {
+  sessionTaskFile as globalSessionTaskFile,
+  legacySessionTaskFile,
+  sessionTasksDir,
+} from "../src/task-paths.js";
 import { TaskStore } from "../src/task-store.js";
 import { mockPi, mockSessionCtx } from "./helpers/mock-pi.js";
 
@@ -32,6 +37,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   delete process.env.PI_TASKS;
+  rmSync(sessionTasksDir(cwd), { recursive: true, force: true });
   rmSync(cwd, { recursive: true, force: true });
 });
 
@@ -39,7 +45,7 @@ afterEach(() => {
 const ctxFor = (sessionId = "s1", opts?: { persisted?: boolean }) =>
   mockSessionCtx(sessionId, { ...opts, cwd });
 const projectFile = () => join(cwd, ".pi", "tasks", "tasks.json");
-const sessionFile = (id: string) => join(cwd, ".pi", "tasks", `tasks-${id}.json`);
+const sessionFile = (id: string) => globalSessionTaskFile(cwd, id);
 
 describe("taskScope: project", () => {
   beforeEach(() => { config.current = { taskScope: "project" }; });
@@ -118,13 +124,14 @@ describe("taskScope: session, without a persisted session", () => {
     expect((await mock.executeTool("TaskList", {})).content[0].text).toContain("Ephemeral");
   });
 
-  it("still writes a session file when the session is persisted", async () => {
+  it("writes persisted session state globally without creating project metadata", async () => {
     const mock = mockPi();
     initExtension(mock.pi as any);
     await mock.fireLifecycle("session_start", { reason: "startup" }, ctxFor("s1"));
     await mock.executeTool("TaskCreate", { subject: "Durable", description: "d" });
 
     expect(existsSync(sessionFile("s1"))).toBe(true);
+    expect(existsSync(join(cwd, ".pi"))).toBe(false);
   });
 
   it("does not fall back to a file when a later lifecycle event fires", async () => {
@@ -170,7 +177,6 @@ describe("PI_TASKS override", () => {
 describe("session_start with a persisted list", () => {
   /** Write a session file holding tasks in the given states. */
   function seed(sessionId: string, statuses: Array<"pending" | "completed">) {
-    mkdirSync(join(cwd, ".pi", "tasks"), { recursive: true });
     const store = new TaskStore(sessionFile(sessionId));
     statuses.forEach((status, i) => {
       const task = store.create(`Task ${i + 1}`, "d");
@@ -214,5 +220,31 @@ describe("session_start with a persisted list", () => {
 
     expect(existsSync(sessionFile("s1"))).toBe(true);
     expect(ctx.ui.setWidget).toHaveBeenCalled();
+  });
+
+  it("lazily migrates the matching legacy workspace file", async () => {
+    const legacyFile = legacySessionTaskFile(cwd, "s1");
+    new TaskStore(legacyFile).create("Legacy task", "d");
+    const mock = mockPi();
+    initExtension(mock.pi as any);
+
+    await mock.fireLifecycle("session_start", { reason: "resume" }, ctxFor("s1"));
+
+    expect(new TaskStore(sessionFile("s1")).list().map(t => t.subject)).toEqual(["Legacy task"]);
+    expect(existsSync(legacyFile)).toBe(false);
+    expect(existsSync(join(cwd, ".pi"))).toBe(false);
+  });
+
+  it("keeps a legacy file when global state already exists", async () => {
+    const legacyFile = legacySessionTaskFile(cwd, "s1");
+    new TaskStore(legacyFile).create("Legacy task", "d");
+    new TaskStore(sessionFile("s1")).create("Global task", "d");
+    const mock = mockPi();
+    initExtension(mock.pi as any);
+
+    await mock.fireLifecycle("session_start", { reason: "resume" }, ctxFor("s1"));
+
+    expect(new TaskStore(sessionFile("s1")).list().map(t => t.subject)).toEqual(["Global task"]);
+    expect(existsSync(legacyFile)).toBe(true);
   });
 });

--- a/test/subagent-integration.test.ts
+++ b/test/subagent-integration.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import initExtension from "../src/index.js";
+import { legacySessionTaskFile, sessionTaskFile, sessionTasksDir } from "../src/task-paths.js";
 import { TaskStore } from "../src/task-store.js";
 import { TaskWidget, type Theme, type UICtx } from "../src/ui/task-widget.js";
 import { installSubagentsMock, type MockEventBus, mockCtx, mockPi, mockSessionCtx } from "./helpers/mock-pi.js";
@@ -39,11 +40,12 @@ describe("Session task rehydration", () => {
   });
   afterEach(() => {
     vi.restoreAllMocks();
+    rmSync(sessionTasksDir(cwd), { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
   });
 
   const sessionCtx = (sessionId: string) => mockSessionCtx(sessionId, { cwd });
-  const sessionFile = (sessionId: string) => join(cwd, ".pi", "tasks", `tasks-${sessionId}.json`);
+  const sessionFile = (sessionId: string) => sessionTaskFile(cwd, sessionId);
 
   it("renders default session-scoped tasks immediately after reload", async () => {
     const sessionId = `reload-${process.pid}-${Date.now()}`;
@@ -178,14 +180,18 @@ describe("Workspace-scoped store resolution", () => {
   };
 
   afterEach(() => {
-    for (const dir of workspaces.splice(0)) rmSync(dir, { recursive: true, force: true });
+    for (const dir of workspaces.splice(0)) {
+      rmSync(sessionTasksDir(dir), { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
-  it("stores session tasks under ctx.cwd instead of the host process cwd", async () => {
+  it("namespaces global session tasks from ctx.cwd instead of the host process cwd", async () => {
     const cwd = workspace("workspace");
     const sessionId = `ctx-cwd-${process.pid}-${Date.now()}`;
-    const taskFile = join(cwd, ".pi", "tasks", `tasks-${sessionId}.json`);
-    const hostTaskFile = join(process.cwd(), ".pi", "tasks", `tasks-${sessionId}.json`);
+    const taskFile = sessionTaskFile(cwd, sessionId);
+    const workspaceTaskFile = legacySessionTaskFile(cwd, sessionId);
+    const hostTaskFile = legacySessionTaskFile(process.cwd(), sessionId);
     delete process.env.PI_TASKS;
     const mock = mockPi();
     initExtension(mock.pi as any);
@@ -198,7 +204,29 @@ describe("Workspace-scoped store resolution", () => {
     }, ctx);
 
     expect(new TaskStore(taskFile).list().map(t => t.subject)).toEqual(["Workspace task"]);
+    expect(existsSync(workspaceTaskFile)).toBe(false);
     expect(existsSync(hostTaskFile)).toBe(false);
+  });
+
+  it("keeps identical session IDs isolated between workspaces", async () => {
+    const cwdA = workspace("namespace-a");
+    const cwdB = workspace("namespace-b");
+    const sessionId = `shared-${process.pid}-${Date.now()}`;
+    delete process.env.PI_TASKS;
+    const mock = mockPi();
+    initExtension(mock.pi as any);
+
+    const ctxA = mockSessionCtx(sessionId, { cwd: cwdA });
+    await mock.fireLifecycle("session_start", { reason: "startup" }, ctxA);
+    await mock.executeTool("TaskCreate", { subject: "Workspace A", description: "d" }, ctxA);
+
+    const ctxB = mockSessionCtx(sessionId, { cwd: cwdB });
+    await mock.fireLifecycle("session_start", { reason: "startup" }, ctxB);
+    await mock.executeTool("TaskCreate", { subject: "Workspace B", description: "d" }, ctxB);
+
+    expect(sessionTaskFile(cwdA, sessionId)).not.toBe(sessionTaskFile(cwdB, sessionId));
+    expect(new TaskStore(sessionTaskFile(cwdA, sessionId)).list().map(t => t.subject)).toEqual(["Workspace A"]);
+    expect(new TaskStore(sessionTaskFile(cwdB, sessionId)).list().map(t => t.subject)).toEqual(["Workspace B"]);
   });
 
   it("loads project scope from ctx.cwd and stores the shared task list there", async () => {
@@ -251,7 +279,7 @@ describe("Workspace-scoped store resolution", () => {
     await mock.fireLifecycle("session_start", { reason: "startup" }, ctxB);
     await mock.executeTool("TaskCreate", { subject: "Task B", description: "Session B" }, ctxB);
 
-    const file = (id: string) => join(cwd, ".pi", "tasks", `tasks-${id}.json`);
+    const file = (id: string) => sessionTaskFile(cwd, id);
     expect(new TaskStore(file(sessionA)).list().map(t => t.subject)).toEqual(["Task A"]);
     expect(new TaskStore(file(sessionB)).list().map(t => t.subject)).toEqual(["Task B"]);
   });


### PR DESCRIPTION
## Summary

- move default session task files to `~/.pi/tasks/sessions/<project-key>/`
- derive collision-resistant project keys from `ExtensionContext.cwd`
- keep project scope and all `PI_TASKS` override behavior unchanged
- migrate matching legacy workspace files lazily without overwriting existing global state
- document new storage and migration behavior

## Migration

When a persisted session opens, its legacy `<workspace>/.pi/tasks/tasks-<sessionId>.json` file is copied to global storage and published atomically. Successful migration removes the legacy file and empty directories. If global state already exists, it wins and the legacy file remains untouched.

## Validation

```text
npm run lint       passed
npm run typecheck  passed
npm run test       349 passed
npm run build      passed
```

Closes #57
